### PR TITLE
Adjusted byte units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
+name = "byte-unit"
+version = "4.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba58563da2fefa88ddca9db6347a1818fc224be2faf916cd4c5e210d2653f4c"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1530,7 @@ name = "ludusavi"
 version = "0.6.0"
 dependencies = [
  "base64 0.12.3",
+ "byte-unit",
  "copypasta",
  "dialoguer",
  "dirs 3.0.1",
@@ -2968,6 +2978,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8-width"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f2c54fe5e8d6907c60dc6fba532cc8529245d97ff4e26cb490cb462de114ba4"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 base64 = "0.12.3"
+byte-unit = "4.0.8"
 copypasta = "0.7.0"
 dialoguer = "0.6.2"
 dirs = "3.0.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -806,7 +806,7 @@ mod tests {
 
 Overall:
   Games: 0
-  Size: 0.00 MiB
+  Size: 0 B
   Location: {}/dev/null
                 "#,
                     &drive()
@@ -859,7 +859,7 @@ Overall:
             );
             assert_eq!(
                 r#"
-foo [0.10 MiB]:
+foo [100.00 KiB]:
   - <drive>/file1
   - [FAILED] <drive>/file2
   - [FAILED] HKEY_CURRENT_USER/Key1
@@ -867,7 +867,7 @@ foo [0.10 MiB]:
 
 Overall:
   Games: 1 of 1
-  Size: 0.10 of 0.15 MiB
+  Size: 100.00 of 150.00 KiB
   Location: <drive>/dev/null
                 "#
                 .trim()
@@ -905,13 +905,13 @@ Overall:
             );
             assert_eq!(
                 r#"
-foo [0.15 MiB]:
+foo [150.00 KiB]:
   - <drive>/original/file1
   - <drive>/original/file2
 
 Overall:
   Games: 1
-  Size: 0.15 MiB
+  Size: 150.00 KiB
   Location: <drive>/dev/null
                 "#
                 .trim()

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -403,7 +403,7 @@ impl GameListEntry {
             config.is_game_enabled_for_backup(&self.scan_info.game_name)
         };
         let name_for_checkbox = self.scan_info.game_name.clone();
-
+        println!("game: {}", self.scan_info.game_name);
         Container::new(
             Column::new()
                 .padding(5)
@@ -442,11 +442,9 @@ impl GameListEntry {
                             .padding(2),
                         )
                         .push(
-                            Container::new(Text::new(
-                                translator.mib(self.scan_info.sum_bytes(&self.backup_info), false),
-                            ))
-                            .width(Length::Units(115))
-                            .center_x(),
+                            Container::new(Text::new(translator.mib(self.scan_info.sum_bytes(&self.backup_info))))
+                                .width(Length::Units(115))
+                                .center_x(),
                         ),
                 )
                 .push(

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -442,9 +442,11 @@ impl GameListEntry {
                             .padding(2),
                         )
                         .push(
-                            Container::new(Text::new(translator.mib(self.scan_info.sum_bytes(&self.backup_info))))
-                                .width(Length::Units(115))
-                                .center_x(),
+                            Container::new(Text::new(
+                                translator.adjusted_size(self.scan_info.sum_bytes(&self.backup_info)),
+                            ))
+                            .width(Length::Units(115))
+                            .center_x(),
                         ),
                 )
                 .push(

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -104,11 +104,11 @@ impl Translator {
     pub fn cli_game_header(&self, name: &str, bytes: u64, decision: &OperationStepDecision) -> String {
         if *decision == OperationStepDecision::Processed {
             match self.language {
-                Language::English => format!("{} [{}]:", name, self.mib(bytes)),
+                Language::English => format!("{} [{}]:", name, self.adjusted_size(bytes)),
             }
         } else {
             match self.language {
-                Language::English => format!("{} [{}] {}:", name, self.mib(bytes), self.label_ignored()),
+                Language::English => format!("{} [{}] {}:", name, self.adjusted_size(bytes), self.label_ignored()),
             }
         }
     }
@@ -137,7 +137,7 @@ impl Translator {
                 Language::English => format!(
                     "\nOverall:\n  Games: {}\n  Size: {}\n  Location: {}",
                     status.total_games,
-                    self.mib(status.total_bytes),
+                    self.adjusted_size(status.total_bytes),
                     location.render()
                 ),
             }
@@ -147,8 +147,8 @@ impl Translator {
                     "\nOverall:\n  Games: {} of {}\n  Size: {} of {}\n  Location: {}",
                     status.processed_games,
                     status.total_games,
-                    self.mib_unlabelled(status.processed_bytes),
-                    self.mib(status.total_bytes),
+                    self.adjusted_size_unlabelled(status.processed_bytes),
+                    self.adjusted_size(status.total_bytes),
                     location.render()
                 ),
             }
@@ -339,13 +339,13 @@ impl Translator {
         .into()
     }
 
-    pub fn mib(&self, bytes: u64) -> String {
+    pub fn adjusted_size(&self, bytes: u64) -> String {
         let byte = Byte::from_bytes(bytes.into());
         let adjusted_byte = byte.get_appropriate_unit(true);
         adjusted_byte.to_string()
     }
 
-    pub fn mib_unlabelled(&self, bytes: u64) -> String {
+    pub fn adjusted_size_unlabelled(&self, bytes: u64) -> String {
         let byte = Byte::from_bytes(bytes.into());
         let adjusted_byte = byte.get_appropriate_unit(true);
         format!("{:.2}", adjusted_byte.get_value())
@@ -354,7 +354,11 @@ impl Translator {
     pub fn processed_games(&self, status: &OperationStatus) -> String {
         if status.completed() {
             match self.language {
-                Language::English => format!("{} games | {}", status.total_games, self.mib(status.total_bytes)),
+                Language::English => format!(
+                    "{} games | {}",
+                    status.total_games,
+                    self.adjusted_size(status.total_bytes)
+                ),
             }
         } else {
             match self.language {
@@ -362,8 +366,8 @@ impl Translator {
                     "{} of {} games | {} of {}",
                     status.processed_games,
                     status.total_games,
-                    self.mib_unlabelled(status.processed_bytes),
-                    self.mib(status.total_bytes)
+                    self.adjusted_size_unlabelled(status.processed_bytes),
+                    self.adjusted_size(status.total_bytes)
                 ),
             }
         }


### PR DESCRIPTION
This change will render sizes adjusted based on the size. When I first saw an entry with "~0", I had to double-check that the files had actual content. Now, sizes small to large will use an appropriate unit.

For example: Before ~0, After: 234 B

Before:
![image](https://user-images.githubusercontent.com/1031558/89111023-9f960700-d416-11ea-8246-206f1b741fff.png)


After:
![image](https://user-images.githubusercontent.com/1031558/89110963-0a930e00-d416-11ea-93c6-7b0c53a8fc20.png)

