### PR TITLE
XDG compliance for ludusavi config

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -162,8 +162,7 @@ pub fn app_dir() -> std::path::PathBuf {
         }
     }
 
-    let mut path = dirs::home_dir().unwrap();
-    path.push(".config");
+    let mut path = dirs::config_dir().unwrap();
     path.push("ludusavi");
     path
 }


### PR DESCRIPTION
This will make so that the current config would not be found so maybe it needs to move files from old location if found. But this would be a more correct way of storing the files. Respecting XDG_CONFIG_HOME etc.