### PR TITLE
Fix importing backups made on a different OS than the host

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -255,24 +255,35 @@ impl StrictPath {
     /// only has to deal with paths that can occur on the host OS.
     #[cfg(target_os = "windows")]
     pub fn split_drive(&self) -> (String, String) {
-        let interpreted = self.interpret();
-
-        if let Some(stripped) = interpreted.strip_prefix(UNC_LOCAL_PREFIX) {
-            // Local UNC path - simplify to a classic drive for user-friendliness:
-            let split: Vec<_> = stripped.splitn(2, '\\').collect();
-            if split.len() == 2 {
-                return (split[0].to_owned(), split[1].replace('\\', "/"));
+        if &self.raw[0..1] == "/" && &self.raw[1..2] != "/" { // Needed when restoring Linux created backups on Windows
+            (
+                "".to_owned(),
+                if self.raw.starts_with('/') {
+                    self.raw[1..].to_string()
+                } else {
+                    self.raw.to_string()
+                },
+            )
+        } else {
+            let interpreted = self.interpret();
+    
+            if let Some(stripped) = interpreted.strip_prefix(UNC_LOCAL_PREFIX) {
+                // Local UNC path - simplify to a classic drive for user-friendliness:
+                let split: Vec<_> = stripped.splitn(2, '\\').collect();
+                if split.len() == 2 {
+                    return (split[0].to_owned(), split[1].replace('\\', "/"));
+                }
+            } else if let Some(stripped) = interpreted.strip_prefix(UNC_PREFIX) {
+                // Remote UNC path - can't simplify to classic drive:
+                let split: Vec<_> = stripped.splitn(2, '\\').collect();
+                if split.len() == 2 {
+                    return (format!("{}{}", UNC_PREFIX, split[0]), split[1].replace('\\', "/"));
+                }
             }
-        } else if let Some(stripped) = interpreted.strip_prefix(UNC_PREFIX) {
-            // Remote UNC path - can't simplify to classic drive:
-            let split: Vec<_> = stripped.splitn(2, '\\').collect();
-            if split.len() == 2 {
-                return (format!("{}{}", UNC_PREFIX, split[0]), split[1].replace('\\', "/"));
-            }
+    
+            // This shouldn't normally happen, but we have a fallback just in case.
+            ("".to_owned(), self.raw.replace('\\', "/"))
         }
-
-        // This shouldn't normally happen, but we have a fallback just in case.
-        ("".to_owned(), self.raw.replace('\\', "/"))
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -842,14 +853,23 @@ mod tests {
         }
 
         #[test]
+        #[cfg(target_os = "windows")]
+        fn can_split_drive_for_linux_path_in_windows() {
+            assert_eq!(
+                (s(""), s("Users/foo/AppData")),
+                StrictPath::new(s("/Users/foo/AppData")).split_drive()
+            );
+        }
+        
+        #[test]
         #[cfg(not(target_os = "windows"))]
         fn can_split_drive_for_windows_path_in_linux() {
             assert_eq!(
-                (s("C"), s("Users/gamer/AppData")),
-                StrictPath::new(s("C:/Users/gamer/AppData")).split_drive()
+                (s("C"), s("Users/foo/AppData")),
+                StrictPath::new(s("C:/Users/foo/AppData")).split_drive()
             );
         }
-
+        
         #[test]
         fn is_prefix_of() {
             assert!(StrictPath::new(s("/")).is_prefix_of(&StrictPath::new(s("/foo"))));


### PR DESCRIPTION
First of all thank you very much for this great tool @mtkennerly ! It's exactly what I was looking for :)

While using it I stumbled upon one tiny problem: When restoring a backup on a Linux machine that was originally created in Windows he resolved path would become "drive-0/C:/...:".
Vice versa when using a Linux made Backup on a Windows host it would also create wrong paths that will error during restoration.

In this pull request I attempt to address this issue. The solution definitely isn't perfect, but now I don't get 0 byte files when restoring backups from other platforms :)
Ideally there'd only be one function handling all cases on both platforms, but the code part checking the interpreted string did not work out of the box on linux.

