### PR TITLE
Add tests for Heroic scanning

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -785,7 +785,7 @@ pub fn run_cli(sub: Subcommand) -> Result<(), Error> {
 
             log::info!("beginning backup with {} steps", subjects.valid.len());
 
-            let heroic_games = HeroicGames::scan(&config.roots, &all_games);
+            let heroic_games = HeroicGames::scan(&config.roots, &all_games, None);
             let layout = BackupLayout::new(backup_dir.clone(), config.backup.retention.clone());
             let filter = config.backup.filter.clone();
             let ranking = InstallDirRanking::scan(&roots, &all_games, &subjects.valid);

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -248,7 +248,7 @@ impl App {
 
         self.register_notify_on_single_game_scanned(&games);
 
-        let heroic_games = std::sync::Arc::new(HeroicGames::scan(&self.config.roots, &all_games));
+        let heroic_games = std::sync::Arc::new(HeroicGames::scan(&self.config.roots, &all_games, None));
         let config = std::sync::Arc::new(self.config.clone());
         let roots = std::sync::Arc::new(config.expanded_roots());
         let layout = std::sync::Arc::new(BackupLayout::new(

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -6,6 +6,10 @@ use crate::path::StrictPath;
 
 pub const EMPTY_HASH: &str = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
 
+pub fn repo() -> String {
+    env!("CARGO_MANIFEST_DIR").replace('\\', "/")
+}
+
 pub fn mapping_file_key(file: &str) -> String {
     if cfg!(target_os = "windows") {
         format!("X:{file}")

--- a/tests/launchers/heroic/GamesConfig/100.json
+++ b/tests/launchers/heroic/GamesConfig/100.json
@@ -1,0 +1,28 @@
+{
+  "100": {
+    "autoInstallDxvk": false,
+    "autoInstallVkd3d": false,
+    "preferSystemLibs": false,
+    "nvidiaPrime": false,
+    "enviromentOptions": [],
+    "wrapperOptions": [
+      {
+        "exe": "/home/root/wrapper.sh",
+        "args": ""
+      }
+    ],
+    "showFps": false,
+    "useGameMode": false,
+    "language": "",
+    "wineVersion": {
+      "bin": "/usr/bin/wine",
+      "name": "Wine Default - wine-ge-7.0 (Staging)",
+      "type": "wine",
+      "wineserver": "/usr/bin/wineserver",
+      "wineboot": "/usr/bin/wineboot"
+    },
+    "winePrefix": "/home/root/Games/Heroic/Prefixes/windows-game"
+  },
+  "version": "v0",
+  "explicit": true
+}

--- a/tests/launchers/heroic/gog_store/installed.json
+++ b/tests/launchers/heroic/gog_store/installed.json
@@ -1,0 +1,17 @@
+{
+  "installed": [
+    {
+      "platform": "windows",
+      "executable": "",
+      "install_path": "C:\\Users\\me\\Games\\Heroic\\windows-game",
+      "install_size": "22.74 MiB",
+      "is_dlc": false,
+      "version": "3.0",
+      "appName": "100",
+      "installedWithDLCs": false,
+      "language": "en-US",
+      "versionEtag": "\"3640869511\"",
+      "buildId": "52095636268561745"
+    }
+  ]
+}

--- a/tests/launchers/heroic/gog_store/library.json
+++ b/tests/launchers/heroic/gog_store/library.json
@@ -1,0 +1,40 @@
+{
+  "games": [
+    {
+      "runner": "gog",
+      "app_name": "100",
+      "cloud_save_enabled": true,
+      "compatible_apps": [],
+      "extra": {
+        "about": {
+          "description": "foo",
+          "shortDescription": ""
+        },
+        "reqs": []
+      },
+      "folder_name": "",
+      "install": {
+        "version": null,
+        "executable": "",
+        "install_path": "",
+        "install_size": "",
+        "is_dlc": false,
+        "platform": ""
+      },
+      "is_game": true,
+      "is_installed": false,
+      "is_ue_asset": false,
+      "is_ue_plugin": false,
+      "is_ue_project": false,
+      "namespace": "windows-game",
+      "save_folder": "",
+      "title": "windows-game",
+      "canRunOffline": true,
+      "is_mac_native": false,
+      "is_linux_native": false
+    }
+  ],
+  "totalGames": 1,
+  "totalMovies": 0,
+  "cloud_saves_enabled": true
+}

--- a/tests/launchers/legendary/installed.json
+++ b/tests/launchers/legendary/installed.json
@@ -1,0 +1,24 @@
+{
+  "100": {
+    "app_name": "100",
+    "base_urls": [
+      "https://example.com/"
+    ],
+    "can_run_offline": true,
+    "egl_guid": "",
+    "executable": "windows-game.exe",
+    "install_path": "C:\\Users\\me\\Games\\Heroic\\windows-game",
+    "install_size": 123,
+    "install_tags": [],
+    "is_dlc": false,
+    "launch_parameters": "",
+    "manifest_path": null,
+    "needs_verification": false,
+    "platform": "Windows",
+    "prereq_info": null,
+    "requires_ot": false,
+    "save_path": null,
+    "title": "windows-game",
+    "version": "1.1"
+  }
+}


### PR DESCRIPTION
@sluedecke Main changes:

* `std::fs::read_to_string(&format!("{}/foo", path.interpret()))` resulted in this error on Windows: `Os { code: 123, kind: InvalidFilename, message: "The filename, directory name, or volume label syntax is incorrect." }`. I changed it to chained `.joined` calls plus using `StrictPath::read`. Another option would have been `StrictPath::new(format!("{}/foo", path.interpret()))` so that we re-`interpret` the final path.
* Allowed passing a specific Legendary location. This is mainly a quick fix for the tests; we'll probably want to tweak this later.

The test files are a mix of the sample from your PR and some from my system (anonymized). The coverage is pretty simple, but we can add more variations of test files as needed.