### PR TITLE
#144: Handle Heroic on Windows

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -785,7 +785,7 @@ pub fn run_cli(sub: Subcommand) -> Result<(), Error> {
 
             log::info!("beginning backup with {} steps", subjects.valid.len());
 
-            let heroic_games = HeroicGames::scan(&config.roots, &all_games, None);
+            let heroic_games = HeroicGames::scan(&roots, &all_games, None);
             let layout = BackupLayout::new(backup_dir.clone(), config.backup.retention.clone());
             let filter = config.backup.filter.clone();
             let ranking = InstallDirRanking::scan(&roots, &all_games, &subjects.valid);

--- a/src/config.rs
+++ b/src/config.rs
@@ -512,7 +512,7 @@ impl Config {
             pf64 = x.trim_end_matches("[\\/]").to_string();
         }
 
-        let candidates = vec![
+        let mut candidates = vec![
             // Steam:
             (format!("{}/Steam", pf32), Store::Steam),
             (format!("{}/Steam", pf64), Store::Steam),
@@ -532,7 +532,6 @@ impl Config {
             (format!("{}/GOG Galaxy/Games", pf32), Store::GogGalaxy),
             (format!("{}/GOG Galaxy/Games", pf64), Store::GogGalaxy),
             // Heroic:
-            // TODO.2022-10-07 heroic: add default windows locations for heroic, probably similar to GOG Galaxy
             ("~/.config/heroic".to_string(), Store::Heroic),
             // TODO.2022-10-20 heroic: flatpak install is not supported yet
             // (
@@ -551,6 +550,13 @@ impl Config {
             // Prime Gaming:
             ("C:/Amazon Games/Library".to_string(), Store::Prime),
         ];
+
+        if let Some(data_dir) = dirs::data_dir() {
+            candidates.push((
+                format!("{}/heroic", crate::path::render_pathbuf(&data_dir)),
+                Store::Heroic,
+            ));
+        }
 
         let detected_steam = match steamlocate::SteamDir::locate() {
             Some(mut steam_dir) => steam_dir

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -248,9 +248,9 @@ impl App {
 
         self.register_notify_on_single_game_scanned(&games);
 
-        let heroic_games = std::sync::Arc::new(HeroicGames::scan(&self.config.roots, &all_games, None));
         let config = std::sync::Arc::new(self.config.clone());
         let roots = std::sync::Arc::new(config.expanded_roots());
+        let heroic_games = std::sync::Arc::new(HeroicGames::scan(&roots, &all_games, None));
         let layout = std::sync::Arc::new(BackupLayout::new(
             self.config.backup.path.clone(),
             config.backup.retention.clone(),

--- a/src/heroic.rs
+++ b/src/heroic.rs
@@ -219,7 +219,7 @@ impl HeroicGames {
         let normalized = normalize_title(title);
         if let Some(official) = self.normalized_to_official.get(&normalized) {
             log::trace!(
-                "memorize_prefix memorizing info for {}: install_dir={:?}, prefix={:?}",
+                "memorize_game memorizing info for {}: install_dir={:?}, prefix={:?}",
                 official,
                 &install_dir,
                 &prefix
@@ -228,11 +228,11 @@ impl HeroicGames {
                 .insert((root.clone(), official.clone()), MemorizedGame { install_dir, prefix });
         } else {
             log::info!(
-                "memorize_prefix did not find {} in manifest, no backup/restore will be done!",
+                "memorize_game did not find {} in manifest, no backup/restore will be done!",
                 title
             );
             log::trace!(
-                "memorize_prefix memorizing info for {}: install_dir={:?}, prefix={:?}",
+                "memorize_game memorizing info for {}: install_dir={:?}, prefix={:?}",
                 title,
                 &install_dir,
                 &prefix

--- a/src/path.rs
+++ b/src/path.rs
@@ -164,7 +164,7 @@ fn splittable(path: &StrictPath) -> String {
 /// This is a wrapper around paths to make it more obvious when we're
 /// converting between different representations. This also handles
 /// things like `~`.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
 pub struct StrictPath {
     raw: String,
     basis: Option<String>,
@@ -205,6 +205,12 @@ impl std::hash::Hash for StrictPath {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.raw.hash(state);
         self.basis.hash(state);
+    }
+}
+
+impl std::fmt::Debug for StrictPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "StrictPath {{ raw: {:?}, basis: {:?} }}", &self.raw, &self.basis)
     }
 }
 


### PR DESCRIPTION
@sluedecke Main changes:

* Added the `install_path` to the data we collect from the Heroic config and passed it along to `prelude::parse_paths`.
  * Ideally, this would be integrated with `InstallDirRanking`, but to keep things simple for now, I left it separate.
* Fixed an issue where we passed the pre-expanded roots (i.e., before handling globs) to `HeroicGames`. That meant the paths had different slash formatting compared to the root lookups we then tried to do later, so it couldn't get the info back out of `HeroicGames`.
* Added a custom Debug impl for StrictPath to make the log output look better.

### Root detection
> ![image](https://user-images.githubusercontent.com/4934192/197641138-956e2914-1bd2-4d79-a959-aea4a3fe8480.png)

### Scanned game from Epic
> ![image](https://user-images.githubusercontent.com/4934192/197641209-3297ae75-645c-4daa-ad52-765575e4313b.png)

### Scanned game from GOG
> ![image](https://user-images.githubusercontent.com/4934192/197641234-1441a075-ab34-411c-b566-9d88ca9353f2.png)
