### PR TITLE
#148: Integrate GOG IDs from manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   * Steam shortcuts for non-Steam games are now detected.
     On all platforms, the shortcut's "start in" folder is used as the `<base>` path.
     On Linux, the shortcut's app ID is used to check `steamapps/compatdata` for Proton saves.
+  * In Heroic roots, Ludusavi can now recognize games by their GOG ID.
+    The CLI `find` command now also has a `--gog-id` option.
 * Changed:
   * Manifest updates now use gzip compression, cutting the download size to about 10% (e.g., 11.4 MiB -> 1.5 MiB).
 * Fixed:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use crate::{
     heroic::HeroicGames,
     lang::Translator,
     layout::BackupLayout,
-    manifest::{Manifest, SteamMetadata},
+    manifest::Manifest,
     prelude::{
         app_dir, back_up_game, prepare_backup_target, scan_game_for_backup, scan_game_for_restoration, BackupId,
         BackupInfo, DuplicateDetector, Error, InstallDirRanking, OperationStatus, OperationStepDecision, ScanChange,
@@ -286,6 +286,10 @@ pub enum Subcommand {
         /// Look up game by a Steam ID.
         #[clap(long)]
         steam_id: Option<u32>,
+
+        /// Look up game by a GOG ID.
+        #[clap(long)]
+        gog_id: Option<u32>,
 
         /// Look up game by an approximation of the title.
         /// Ignores capitalization, "edition" suffixes, year suffixes, and some special symbols.
@@ -880,7 +884,7 @@ pub fn run_cli(sub: Subcommand) -> Result<(), Error> {
                 .map(|(i, name)| {
                     log::trace!("step {i} / {}: {name}", subjects.valid.len());
                     let game = &all_games.0[name];
-                    let steam_id = &game.steam.clone().unwrap_or(SteamMetadata { id: None }).id;
+                    let steam_id = game.steam.as_ref().and_then(|x| x.id);
 
                     let previous = layout.latest_backup(name, false, &config.redirects);
 
@@ -890,7 +894,7 @@ pub fn run_cli(sub: Subcommand) -> Result<(), Error> {
                         &roots,
                         &StrictPath::from_std_path_buf(&app_dir()),
                         &heroic_games,
-                        steam_id,
+                        &steam_id,
                         &filter,
                         &wine_prefix,
                         &ranking,
@@ -1160,6 +1164,7 @@ pub fn run_cli(sub: Subcommand) -> Result<(), Error> {
             backup,
             restore,
             steam_id,
+            gog_id,
             normalized,
             names,
         } => {
@@ -1194,7 +1199,7 @@ pub fn run_cli(sub: Subcommand) -> Result<(), Error> {
             let layout = BackupLayout::new(restore_dir.clone(), config.backup.retention.clone());
 
             let title_finder = TitleFinder::new(&manifest, &layout);
-            let found = title_finder.find(&names, &steam_id, normalized, backup, restore);
+            let found = title_finder.find(&names, &steam_id, &gog_id, normalized, backup, restore);
             reporter.add_found_titles(&found);
 
             if found.is_empty() {
@@ -1647,6 +1652,7 @@ mod tests {
                         backup: false,
                         restore: false,
                         steam_id: None,
+                        gog_id: None,
                         normalized: false,
                         names: vec![],
                     }),
@@ -1666,7 +1672,9 @@ mod tests {
                     "--backup",
                     "--restore",
                     "--steam-id",
-                    "123",
+                    "101",
+                    "--gog-id",
+                    "102",
                     "--normalized",
                     "game1",
                     "game2",
@@ -1677,7 +1685,8 @@ mod tests {
                         path: Some(StrictPath::new(s("tests/backup"))),
                         backup: true,
                         restore: true,
-                        steam_id: Some(123),
+                        steam_id: Some(101),
+                        gog_id: Some(102),
                         normalized: true,
                         names: vec![s("game1"), s("game2")],
                     }),

--- a/src/heroic.rs
+++ b/src/heroic.rs
@@ -152,6 +152,8 @@ impl HeroicGames {
                                 game.title,
                                 game.app_name
                             );
+                            let official_title =
+                                title_finder.find_one(&[game.title.to_owned()], &None, &None, true, true, false);
                             // process game from GamesConfig
                             let prefix = self.find_prefix(
                                 &root.path,
@@ -161,8 +163,8 @@ impl HeroicGames {
                             );
                             self.memorize_game(
                                 root,
-                                title_finder,
                                 &game.title,
+                                official_title,
                                 StrictPath::new(game.install_path.clone()),
                                 prefix,
                             );
@@ -214,11 +216,14 @@ impl HeroicGames {
         if let Ok(installed_games) = serde_json::from_str::<HeroicInstalled>(&content.unwrap_or_default()) {
             for game in installed_games.installed {
                 if let Some(game_title) = game_titles.get(&game.app_name) {
+                    let gog_id: Option<u32> = game.app_name.parse().ok();
+                    let official_title =
+                        title_finder.find_one(&[game_title.to_owned()], &None, &gog_id, true, true, false);
                     let prefix = self.find_prefix(&root.path, game_title, &game.platform, &game.app_name);
                     self.memorize_game(
                         root,
-                        title_finder,
                         game_title,
+                        official_title,
                         StrictPath::new(game.install_path),
                         prefix,
                     );
@@ -230,16 +235,16 @@ impl HeroicGames {
     fn memorize_game(
         &mut self,
         root: &RootsConfig,
-        title_finder: &TitleFinder,
-        title: &str,
+        heroic_title: &str,
+        official_title: Option<String>,
         install_dir: StrictPath,
         prefix: Option<StrictPath>,
     ) {
-        if let Some(official) = title_finder.find_one(&[title.to_owned()], &None, true, true, false) {
+        if let Some(official) = official_title {
             log::trace!(
                 "memorize_game memorizing info for '{}' (from: '{}'): install_dir={:?}, prefix={:?}",
                 official,
-                title,
+                heroic_title,
                 &install_dir,
                 &prefix
             );
@@ -247,7 +252,7 @@ impl HeroicGames {
                 .insert((root.clone(), official), MemorizedGame { install_dir, prefix });
         } else {
             // Handling game name mismatches, e.g. GRIP vs. GRIP: Combat Racing
-            let log_message = format!("Ignoring unrecognized Heroic game: '{}'", title);
+            let log_message = format!("Ignoring unrecognized Heroic game: '{}'", heroic_title);
             if std::env::var("LUDUSAVI_DEBUG").is_ok() {
                 eprintln!("{}", &log_message);
             }
@@ -255,12 +260,14 @@ impl HeroicGames {
 
             log::trace!(
                 "memorize_game memorizing info for '{}': install_dir={:?}, prefix={:?}",
-                title,
+                heroic_title,
                 &install_dir,
                 &prefix
             );
-            self.games
-                .insert((root.clone(), title.to_string()), MemorizedGame { install_dir, prefix });
+            self.games.insert(
+                (root.clone(), heroic_title.to_string()),
+                MemorizedGame { install_dir, prefix },
+            );
         }
     }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1591,6 +1591,7 @@ pub struct TitleFinder {
     can_backup: std::collections::HashSet<String>,
     can_restore: std::collections::HashSet<String>,
     steam_ids: std::collections::HashMap<u32, String>,
+    gog_ids: std::collections::HashMap<u32, String>,
     normalized: std::collections::HashMap<String, String>,
 }
 
@@ -1600,6 +1601,7 @@ impl TitleFinder {
         let can_restore: std::collections::HashSet<_> = layout.restorable_games().into_iter().collect();
         let all_games: std::collections::HashSet<_> = can_backup.union(&can_restore).cloned().collect();
         let steam_ids = manifest.map_steam_ids_to_names();
+        let gog_ids = manifest.map_gog_ids_to_names();
         let normalized: std::collections::HashMap<_, _> = all_games
             .iter()
             .map(|title| (normalize_title(title), title.to_owned()))
@@ -1610,6 +1612,7 @@ impl TitleFinder {
             can_backup,
             can_restore,
             steam_ids,
+            gog_ids,
             normalized,
         }
     }
@@ -1633,11 +1636,12 @@ impl TitleFinder {
         &self,
         names: &[String],
         steam_id: &Option<u32>,
+        gog_id: &Option<u32>,
         normalized: bool,
         backup: bool,
         restore: bool,
     ) -> Option<String> {
-        let found = self.find(names, steam_id, normalized, backup, restore);
+        let found = self.find(names, steam_id, gog_id, normalized, backup, restore);
         found.iter().next().map(|x| x.to_owned())
     }
 
@@ -1645,6 +1649,7 @@ impl TitleFinder {
         &self,
         names: &[String],
         steam_id: &Option<u32>,
+        gog_id: &Option<u32>,
         normalized: bool,
         backup: bool,
         restore: bool,
@@ -1653,6 +1658,15 @@ impl TitleFinder {
 
         if let Some(steam_id) = steam_id {
             if let Some(found) = self.steam_ids.get(steam_id) {
+                if self.eligible(found, backup, restore) {
+                    output.insert(found.to_owned());
+                    return output;
+                }
+            }
+        }
+
+        if let Some(gog_id) = gog_id {
+            if let Some(found) = self.gog_ids.get(gog_id) {
                 if self.eligible(found, backup, restore) {
                     output.insert(found.to_owned());
                     return output;


### PR DESCRIPTION
@sluedecke Would you mind testing this out? The manifest has GOG IDs for A-J games so far.

I used u32 for the GOG ID, but the IDs do seem a lot larger than Steam IDs, so I'm not sure if u64 would be better pre-emptively.

Should work in Heroic scans and using the `find` command:

```bash
$ cargo run -- find --gog-id 1237807960
Dead Cells
```