### PR TITLE
Update to Iced 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+* Added:
+  * GUI: Thanks to updates in [Iced](https://github.com/iced-rs/iced),
+    there is now much better support for non-ASCII characters.
+    This means that several translations are now properly supported:
+    Simplified Chinese, Japanese, Korean, and Thai.
+
+    Unfortunately, there are still technical limitations with Arabic,
+    so that translation remains experimental via the config file.
+
 ## v0.20.0 (2023-07-10)
 
 * Added:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -35,9 +35,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -56,12 +56,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.20"
+name = "ahash"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "memchr",
+ "cfg-if",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -72,6 +74,42 @@ checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "android-activity"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40bc1575e653f158cbdc6ebcd917b9564e66321c5325c232c3591269c257be69"
+dependencies = [
+ "android-properties",
+ "bitflags 1.3.2",
+ "cc",
+ "jni-sys",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum 0.6.1",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android-tzdata"
@@ -105,15 +143,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "ascii"
@@ -132,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0122885821398cc923ece939e24d1056a2384ee719432397fa9db87230ff11"
+checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
 dependencies = [
  "flate2",
  "futures-core",
@@ -162,15 +194,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -215,6 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,13 +268,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.5.0"
+name = "block-sys"
+version = "0.1.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
+checksum = "0fa55741ee90902547802152aaf3f8e5248aab7e21468089560d4c8840561146"
+dependencies = [
+ "objc-sys",
+]
+
+[[package]]
+name = "block2"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
+dependencies = [
+ "block-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "bstr"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "once_cell",
  "regex-automata",
  "serde",
 ]
@@ -274,7 +330,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -316,7 +372,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e0d00eb1ea24371a97d2da6201c6747a633dc6dc1988ef503403b4c59504a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "log",
  "nix 0.25.1",
  "slotmap",
@@ -340,13 +396,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cgl"
-version = "0.3.2"
+name = "cfg_aliases"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
-dependencies = [
- "libc",
-]
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -381,10 +434,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -460,16 +513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983a7010836ecd04dde2c6d27a0cb56ec5d21572177e782bdcb24a600124e921"
 dependencies = [
  "thiserror",
- "x11rb",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
+ "x11rb 0.9.0",
 ]
 
 [[package]]
@@ -478,12 +522,12 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "cocoa-foundation",
  "core-foundation",
  "core-graphics",
- "foreign-types 0.3.2",
+ "foreign-types",
  "libc",
  "objc",
 ]
@@ -494,11 +538,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.3.2",
+ "foreign-types",
  "libc",
  "objc",
 ]
@@ -539,12 +583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_panic"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6051f239ecec86fde3410901ab7860d458d160371533842974fc61f96d15879b"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,42 +610,49 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.3.2",
+ "foreign-types",
  "libc",
 ]
 
 [[package]]
 name = "core-graphics-types"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
+checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
- "foreign-types 0.3.2",
  "libc",
 ]
 
 [[package]]
-name = "core-text"
-version = "19.2.0"
+name = "cosmic-text"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
+checksum = "b0b68966c2543609f8d92f9d33ac3b719b2a67529b0c6c0b3e025637b477eef9"
 dependencies = [
- "core-foundation",
- "core-graphics",
- "foreign-types 0.3.2",
- "libc",
+ "aliasable",
+ "fontdb",
+ "libm",
+ "log",
+ "rangemap",
+ "rustybuzz",
+ "swash",
+ "sys-locale",
+ "unicode-bidi",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -675,27 +720,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossfont"
-version = "0.5.1"
+name = "crunchy"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fd3add36ea31aba1520aa5288714dd63be506106753226d0eb387a93bc9c45"
-dependencies = [
- "cocoa",
- "core-foundation",
- "core-foundation-sys",
- "core-graphics",
- "core-text",
- "dwrote",
- "foreign-types 0.5.0",
- "freetype-rs",
- "libc",
- "log",
- "objc",
- "once_cell",
- "pkg-config",
- "servo-fontconfig",
- "winapi",
-]
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -705,16 +733,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -729,44 +747,9 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libloading 0.7.4",
  "winapi",
-]
-
-[[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -862,7 +845,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -881,56 +864,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "dwrote"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
-dependencies = [
- "lazy_static",
- "libc",
- "serde",
- "serde_derive",
- "winapi",
- "wio",
-]
-
-[[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
-name = "encase"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a516181e9a36e8982cb37933c5e7dba638c42938cacde46ee4e5b4156f881b9"
-dependencies = [
- "const_panic",
- "encase_derive",
- "glam",
- "thiserror",
-]
-
-[[package]]
-name = "encase_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5b802412eea315f29f2bb2da3a5963cd6121f56eaa06aebcdc0c54eea578f22"
-dependencies = [
- "encase_derive_impl",
-]
-
-[[package]]
-name = "encase_derive_impl"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2f4de457d974f548d2c2a16f709ebd81013579e543bd1a9b19ced88132c2cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encode_unicode"
@@ -948,10 +885,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.1"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -979,6 +922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etagere"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf22f748754352918e082e0039335ee92454a5d62bcaf69b5e8daf5907d9644"
+dependencies = [
+ "euclid",
+ "svg_fmt",
+]
+
+[[package]]
 name = "euclid"
 version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,14 +941,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "expat-sys"
-version = "2.1.6"
+name = "fast-srgb8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
-dependencies = [
- "cmake",
- "pkg-config",
-]
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -1005,6 +954,12 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fdeflate"
@@ -1028,29 +983,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-crate"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
-dependencies = [
- "toml",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
 name = "flexi_logger"
-version = "0.25.5"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e7b68b1f7ce9c62856598e99cd6742b9cedb6186b47aa989a82640f20bfa9b"
+checksum = "84075a94fd76ea9b7a0d2c257444ae30356e58fdac6cd0fe68af33f5279981ae"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -1063,12 +1009,6 @@ dependencies = [
  "regex",
  "thiserror",
 ]
-
-[[package]]
-name = "float-ord"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bad48618fdb549078c333a7a8528acb57af271d0433bdecd523eb620628364e"
 
 [[package]]
 name = "fluent"
@@ -1121,28 +1061,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "font-kit"
-version = "0.10.1"
+name = "fontdb"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c9a156ec38864999bc9c4156e5f3b50224d4a5578028a64e5a3875caa9ee28"
+checksum = "af8d8cbea8f21307d7e84bca254772981296f058a1d36b461bf4d83a7499fc9e"
 dependencies = [
- "bitflags",
- "byteorder",
- "core-foundation",
- "core-graphics",
- "core-text",
- "dirs-next",
- "dwrote",
- "float-ord",
- "freetype",
- "lazy_static",
- "libc",
  "log",
- "pathfinder_geometry",
- "pathfinder_simd",
- "servo-fontconfig",
- "walkdir",
- "winapi",
+ "memmap2 0.6.2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -1151,28 +1079,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared 0.3.1",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1182,50 +1089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "freetype"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee38378a9e3db1cc693b4f88d166ae375338a0ff75cb8263e1c601d51f35dc6"
-dependencies = [
- "freetype-sys",
- "libc",
-]
-
-[[package]]
-name = "freetype-rs"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74eadec9d0a5c28c54bb9882e54787275152a4e36ce206b45d7451384e5bf5fb"
-dependencies = [
- "bitflags",
- "freetype-sys",
- "libc",
-]
-
-[[package]]
-name = "freetype-sys"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
-dependencies = [
- "cmake",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -1285,7 +1154,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1328,15 +1197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,26 +1229,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
-
-[[package]]
-name = "gl_generator"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
-dependencies = [
- "khronos_api",
- "log",
- "xml-rs",
-]
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glam"
-version = "0.21.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+checksum = "42218cb640844e3872cc3c153dc975229e080a6c4733b34709ef445610550226"
 
 [[package]]
 name = "glob"
@@ -1404,11 +1253,11 @@ checksum = "a1de3b561f26b63d940152189e4e712a7f45b95773a21abd6b3e28eb890a532c"
 
 [[package]]
 name = "globset"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+checksum = "aca8bbd8e0707c1887a8bbb7e6b40e228f251ff5d62c8220a4a7a53c73aff006"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "bstr",
  "fnv",
  "log",
@@ -1417,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bd5877156a19b8ac83a29b2306fe20537429d318f3ff0a1a2119f8d9c61919"
+checksum = "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1428,130 +1277,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "glow"
-version = "0.12.2"
+name = "glyphon"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807edf58b70c0b5b2181dd39fe1839dbdb3ba02645630dc5f753e23da307f762"
+checksum = "5e87caa7459145f5e5f167bf34db4532901404c679e62339fb712a0e3ccf722a"
 dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glow_glyph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4e62c64947b9a24fe20e2bba9ad819ecb506ef5c8df7ffc4737464c6df9510"
-dependencies = [
- "bytemuck",
- "glow 0.11.2",
- "glyph_brush",
- "log",
-]
-
-[[package]]
-name = "glutin"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444c9ad294fdcaf20ccf6726b78f380b5450275540c9b68ab62f49726ad1c713"
-dependencies = [
- "cgl",
- "cocoa",
- "core-foundation",
- "glutin_egl_sys",
- "glutin_gles2_sys",
- "glutin_glx_sys",
- "glutin_wgl_sys",
- "libloading 0.7.4",
- "log",
- "objc",
- "once_cell",
- "osmesa-sys",
- "parking_lot 0.12.1",
- "raw-window-handle 0.5.2",
- "wayland-client",
- "wayland-egl",
- "winapi",
- "winit",
-]
-
-[[package]]
-name = "glutin_egl_sys"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68900f84b471f31ea1d1355567eb865a2cf446294f06cef8d653ed7bcf5f013d"
-dependencies = [
- "gl_generator",
- "winapi",
-]
-
-[[package]]
-name = "glutin_gles2_sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094e708b730a7c8a1954f4f8a31880af00eb8a1c5b5bf85d28a0a3c6d69103"
-dependencies = [
- "gl_generator",
- "objc",
-]
-
-[[package]]
-name = "glutin_glx_sys"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93d0575865098580c5b3a423188cd959419912ea60b1e48e8b3b526f6d02468"
-dependencies = [
- "gl_generator",
- "x11-dl",
-]
-
-[[package]]
-name = "glutin_wgl_sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5951a1569dbab865c6f2a863efafff193a93caf05538d193e9e3816d21696"
-dependencies = [
- "gl_generator",
-]
-
-[[package]]
-name = "glyph_brush"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edefd123f28a0b1d41ec4a489c2b43020b369180800977801611084f342978d"
-dependencies = [
- "glyph_brush_draw_cache",
- "glyph_brush_layout",
- "ordered-float",
- "rustc-hash",
- "twox-hash",
-]
-
-[[package]]
-name = "glyph_brush_draw_cache"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6010675390f6889e09a21e2c8b575b3ee25667ea8237a8d59423f73cb8c28610"
-dependencies = [
- "ab_glyph",
- "crossbeam-channel",
- "crossbeam-deque",
- "linked-hash-map",
- "rayon",
- "rustc-hash",
-]
-
-[[package]]
-name = "glyph_brush_layout"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc32c2334f00ca5ac3695c5009ae35da21da8c62d255b5b96d56e2597a637a38"
-dependencies = [
- "ab_glyph",
- "approx",
- "xi-unicode",
+ "cosmic-text",
+ "etagere",
+ "lru",
+ "wgpu",
 ]
 
 [[package]]
@@ -1560,7 +1294,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22beaafc29b38204457ea030f6fb7a84c9e4dd1b86e311ba0542533453d87f62"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gpu-alloc-types",
 ]
 
@@ -1570,7 +1304,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1592,9 +1326,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1603,7 +1337,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1618,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -1628,11 +1362,21 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -1641,16 +1385,26 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
 ]
 
 [[package]]
 name = "hassle-rs"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90601c6189668c7345fc53842cb3f3a3d872203d523be1b3cb44a36a3e62fb85"
+checksum = "1397650ee315e8891a0df210707f0fc61771b0cc518c3023896064c5407cb3b0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "com-rs",
  "libc",
  "libloading 0.7.4",
@@ -1676,18 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hexf-parse"
@@ -1740,9 +1485,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1764,10 +1509,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "rustls",
@@ -1800,39 +1546,40 @@ dependencies = [
 
 [[package]]
 name = "iced"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbddf356d01e9d41cd394a9d04d62bfd89650a30f12fda5839cabb8c4591c88"
+checksum = "c708807ec86f99dd729dc4d42db5239acf118cec14d3c5f57679dcfdbbc472b1"
 dependencies = [
  "iced_core",
  "iced_futures",
- "iced_glow",
- "iced_glutin",
- "iced_graphics",
- "iced_native",
- "iced_wgpu",
+ "iced_renderer",
+ "iced_widget",
  "iced_winit",
  "thiserror",
 ]
 
 [[package]]
 name = "iced_core"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e1942e28dedee756cc27e67e7a838cdc1e59fb6bf9627ec9f709ab3b135782"
+checksum = "64d0bc4fbf018576d08d93f838e6058cc6f10bbc05e04ae249a2a44dffb4ebc8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "instant",
+ "log",
  "palette",
+ "thiserror",
+ "twox-hash",
 ]
 
 [[package]]
 name = "iced_futures"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215d51fa4f70dbb63775d7141243c4d98d4d525d8949695601f8fbac7dcbc04e"
+checksum = "14dab0054a9c7a1cbce227a8cd9ee4a094497b3d06094551ac6c1488d563802e"
 dependencies = [
  "futures",
+ "iced_core",
  "log",
  "tokio",
  "wasm-bindgen-futures",
@@ -1840,71 +1587,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "iced_glow"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc5b081015f5c75777c96ad75e2288916e7d444c97396d6d136517877ef9129"
-dependencies = [
- "bytemuck",
- "euclid",
- "glow 0.11.2",
- "glow_glyph",
- "glyph_brush",
- "iced_graphics",
- "iced_native",
- "log",
-]
-
-[[package]]
-name = "iced_glutin"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c427ca018d29508512581d832fbaa7b6c8ec34c39d438f35f59e363a6419953"
-dependencies = [
- "glutin",
- "iced_graphics",
- "iced_native",
- "iced_winit",
- "log",
-]
-
-[[package]]
 name = "iced_graphics"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338a6aff7db906537074ad0fe8b720cfdb9512cdfea43c628c76bd1cf50fdcc0"
+checksum = "67ff14447a221e9e9205a13d84d7bbdf0636a3b1daa02cfca690ed09689c4d2b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytemuck",
- "font-kit",
  "glam",
- "iced_native",
- "iced_style",
+ "half",
+ "iced_core",
  "log",
  "raw-window-handle 0.5.2",
  "thiserror",
 ]
 
 [[package]]
-name = "iced_native"
-version = "0.10.3"
+name = "iced_renderer"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012eb06da490fe46a695b39721c20da9643f35cf2ecb9d30618fdeb96170616"
+checksum = "1033385b0db0099a0d13178c9ff93c1ce11e7d0177522acf578bf79febdb2af8"
+dependencies = [
+ "iced_graphics",
+ "iced_tiny_skia",
+ "iced_wgpu",
+ "log",
+ "raw-window-handle 0.5.2",
+ "thiserror",
+]
+
+[[package]]
+name = "iced_runtime"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c85c5768d0e9a4997cf8bf39e7ad45da4cc3ffdaece107512943452a019b7a"
 dependencies = [
  "iced_core",
  "iced_futures",
- "iced_style",
- "num-traits",
  "thiserror",
- "twox-hash",
- "unicode-segmentation",
 ]
 
 [[package]]
 name = "iced_style"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e37333dc2991201140302cd0d4cea051bd37ca3671d5008ec85df86d232ff30"
+checksum = "d85c47d9d13e2281f75ddf98c865daf2101632bd2b855c401dd0b1c8b81a31a0"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -1912,48 +1639,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "iced_wgpu"
-version = "0.10.0"
+name = "iced_tiny_skia"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478803c56061f567ce5ddf223b20d11d3c118cc46bb0d0552370dc65cdc4cb9c"
+checksum = "c7715f6222c9470bbbd75a39f70478fa0d1bdfb81a377a34fd1b090ffccc480b"
 dependencies = [
- "bitflags",
  "bytemuck",
- "encase",
- "futures",
- "glam",
- "glyph_brush",
- "guillotiere",
+ "cosmic-text",
  "iced_graphics",
- "iced_native",
+ "kurbo",
  "log",
  "raw-window-handle 0.5.2",
+ "rustc-hash",
+ "softbuffer",
+ "tiny-skia 0.10.0",
+ "twox-hash",
+]
+
+[[package]]
+name = "iced_wgpu"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467a01e8ac3bcd6607e3c4da0c775aa9559027182c3b953f111bddc944a459ab"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytemuck",
+ "futures",
+ "glam",
+ "glyphon",
+ "guillotiere",
+ "iced_graphics",
+ "log",
+ "once_cell",
+ "raw-window-handle 0.5.2",
+ "rustc-hash",
+ "twox-hash",
  "wgpu",
- "wgpu_glyph",
+]
+
+[[package]]
+name = "iced_widget"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b814ddf36a63f7f66ad91a4c1f298a2478f04d7ddc083a747ec339c7f87a2b"
+dependencies = [
+ "iced_renderer",
+ "iced_runtime",
+ "iced_style",
+ "num-traits",
+ "thiserror",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "iced_winit"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a59ea3a85149a6a1f9e92b6c740ce90f04e5c7d848cfd05742336863fceb955"
+checksum = "0ecea26fcc8074373f6011d2193d63445617d900a428eb4df66c0e5658408fb6"
 dependencies = [
- "iced_futures",
  "iced_graphics",
- "iced_native",
+ "iced_runtime",
+ "iced_style",
  "log",
+ "raw-window-handle 0.5.2",
  "thiserror",
  "web-sys",
  "winapi",
  "window_clipboard",
  "winit",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1986,7 +1740,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -2048,25 +1812,24 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
+ "hermit-abi 0.3.2",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -2082,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jni-sys"
@@ -2147,10 +1910,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "khronos_api"
-version = "3.1.0"
+name = "kurbo"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2160,9 +1926,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -2185,6 +1951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,9 +1964,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -2211,6 +1983,15 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+
+[[package]]
+name = "lru"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eedb2bdbad7e0634f83989bf596f497b070130daaa398ab22d84c39e266deec5"
+dependencies = [
+ "hashbrown 0.14.0",
+]
 
 [[package]]
 name = "ludusavi"
@@ -2230,7 +2011,6 @@ dependencies = [
  "globetter",
  "globset",
  "iced",
- "iced_native",
  "iced_style",
  "image",
  "indicatif",
@@ -2294,10 +2074,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d28bba84adfe6646737845bc5ebbfa2c08424eb1c37e94a1fd2a82adb56a872"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -2317,10 +2115,10 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-graphics-types",
- "foreign-types 0.3.2",
+ "foreign-types",
  "log",
  "objc",
 ]
@@ -2336,15 +2134,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2370,15 +2159,15 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.11.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3d4269bcb7d50121097702fde1afb75f4ea8083aeb7a55688dcf289a853271"
+checksum = "bbcc2e0513220fd2b598e6068608d4462db20322c0e77e47f6f488dfcfc279cb"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "codespan-reporting",
  "hexf-parse",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "num-traits",
  "rustc-hash",
@@ -2415,10 +2204,10 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys",
- "num_enum",
+ "num_enum 0.5.11",
  "raw-window-handle 0.5.2",
  "thiserror",
 ]
@@ -2428,35 +2217,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-glue"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0434fabdd2c15e0aab768ca31d5b7b333717f03cf02037d5a0a3ff3c278ed67f"
-dependencies = [
- "libc",
- "log",
- "ndk",
- "ndk-context",
- "ndk-macro",
- "ndk-sys",
- "once_cell",
- "parking_lot 0.12.1",
-]
-
-[[package]]
-name = "ndk-macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
-dependencies = [
- "darling",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -2473,7 +2233,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if",
  "libc",
@@ -2486,7 +2246,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
@@ -2499,10 +2259,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2517,11 +2291,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.47.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df031e117bca634c262e9bd3173776844b6c17a90b3741c9163663b4385af76"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
 dependencies = [
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2547,20 +2321,20 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -2570,7 +2344,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -2583,6 +2366,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2613,6 +2408,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.2.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
+
+[[package]]
+name = "objc2"
+version = "0.3.0-beta.3.patch-leaks.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e01640f9f2cb1220bbe80325e179e532cb3379ebcd1bf2279d703c19fe3a468"
+dependencies = [
+ "block2",
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "2.0.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abfcac41015b00a120608fdaa6938c44cb983fee294351cc4bac7638b4e50512"
+dependencies = [
+ "objc-sys",
+]
+
+[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
@@ -2656,12 +2477,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "3.7.0"
+name = "orbclient"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+checksum = "221d488cd70617f1bd599ed8ceb659df2147d9393717954d82a0f5e8032a6ab1"
 dependencies = [
- "num-traits",
+ "redox_syscall 0.3.5",
 ]
 
 [[package]]
@@ -2669,24 +2490,6 @@ name = "os_str_bytes"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
-
-[[package]]
-name = "osmesa-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
-dependencies = [
- "shared_library",
-]
-
-[[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "owned_ttf_parser"
@@ -2699,26 +2502,25 @@ dependencies = [
 
 [[package]]
 name = "palette"
-version = "0.6.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9cd68f7112581033f157e56c77ac4a5538ec5836a2e39284e65bd7d7275e49"
+checksum = "e1641aee47803391405d0a1250e837d2336fdddd18b27f3ddb8c1d80ce8d7f43"
 dependencies = [
  "approx",
- "num-traits",
+ "fast-srgb8",
  "palette_derive",
  "phf",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.6.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05eedf46a8e7c27f74af0c9cfcdb004ceca158cb1b918c6f68f8d7a549b3e427"
+checksum = "3c02bfa6b3ba8af5434fa0531bf5701f750d983d4260acd6867faca51cdc4484"
 dependencies = [
- "find-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2766,7 +2568,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -2782,28 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
-
-[[package]]
-name = "pathfinder_geometry"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
-dependencies = [
- "log",
- "pathfinder_simd",
-]
-
-[[package]]
-name = "pathfinder_simd"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fe46acc5503595e5949c17b818714d26fdf9b4920eacf3b2947f0199f4a6ff"
-dependencies = [
- "rustc_version",
-]
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbkdf2"
@@ -2825,9 +2608,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2835,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "5f94bca7e7a599d89dea5dfa309e217e7906c3c007fb9c3299c40b10d6a315d3"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2845,22 +2628,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "99d490fe7e8556575ff6911e45567ab95e71617f43781e5c05490dc8d75c965c"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "2674c66ebb4b4d9036012091b537aae5878970d6999f81a265034d85b136b341"
 dependencies = [
  "once_cell",
  "pest",
@@ -2869,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2879,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
  "rand",
@@ -2889,31 +2672,31 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -2933,11 +2716,11 @@ version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59871cc5b6cce7eaccca5a802b4173377a1c2ba90654246789a8fa2334426d11"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2948,13 +2731,11 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "pretty_assertions"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
- "ctor",
  "diff",
- "output_vt100",
  "yansi",
 ]
 
@@ -2994,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3008,10 +2789,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
 
 [[package]]
-name = "quote"
-version = "1.0.28"
+name = "quick-xml"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -3053,14 +2843,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
-name = "raw-window-handle"
-version = "0.3.4"
+name = "rangemap"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28f55143d0548dad60bb4fbdc835a3d7ac6acc3324506450c5fdd6e42903a76"
-dependencies = [
- "libc",
- "raw-window-handle 0.4.3",
-]
+checksum = "8b9283c6b06096b47afc7109834fdedab891175bb5241ee5d4f7d2546549f263"
 
 [[package]]
 name = "raw-window-handle"
@@ -3105,7 +2891,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3114,7 +2900,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3130,32 +2916,38 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
- "aho-corasick 1.0.2",
+ "aho-corasick",
  "memchr",
+ "regex-automata",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "renderdoc-sys"
-version = "0.7.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
+checksum = "216080ab382b992234dda86873c18d4c48358f5cfcb70fd693d7f6f2131b628b"
 
 [[package]]
 name = "reqwest"
@@ -3226,23 +3018,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
@@ -3250,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
@@ -3262,37 +3044,45 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
 dependencies = [
  "ring",
  "untrusted",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.13"
+name = "rustybuzz"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "82eea22c8f56965eeaf3a209b3d24508256c7b920fb3b6211b8ba0f7c0583250"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytemuck",
+ "libm",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-general-category",
+ "unicode-script",
+]
 
 [[package]]
-name = "safe_arch"
-version = "0.5.2"
+name = "ryu"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ff3d6d9696af502cc3110dacce942840fb06ff4514cad92236ecc455f2ce05"
-dependencies = [
- "bytemuck",
-]
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -3311,9 +3101,9 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -3327,14 +3117,15 @@ dependencies = [
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.4.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61270629cc6b4d77ec1907db1033d5c2e1a404c412743621981a871dc9c12339"
+checksum = "cda4e97be1fd174ccc2aae81c8b694e803fa99b34e8fd0f057a9d70698e3ed09"
 dependencies = [
- "crossfont",
+ "ab_glyph",
  "log",
+ "memmap2 0.5.10",
  "smithay-client-toolkit",
- "tiny-skia",
+ "tiny-skia 0.8.4",
 ]
 
 [[package]]
@@ -3344,48 +3135,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ef965a420fe14fdac7dd018862966a4c14094f900e1650bbc71ddd7d580c8af"
 
 [[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
-
-[[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "60363bdd39a7be0266a520dab25fdc9241d2f987b08a01e01f0ec6d06a981348"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "f28482318d6641454cb273da158647922d1be6b5a2fcc6165cd89ebdd7ed576b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -3410,31 +3183,10 @@ version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "ryu",
  "serde",
  "yaml-rust",
-]
-
-[[package]]
-name = "servo-fontconfig"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e3e22fe5fd73d04ebf0daa049d3efe3eae55369ce38ab16d07ddd9ac5c217c"
-dependencies = [
- "libc",
- "servo-fontconfig-sys",
-]
-
-[[package]]
-name = "servo-fontconfig-sys"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36b879db9892dfa40f95da1c38a835d41634b825fbd8c4c418093d53c24b388"
-dependencies = [
- "expat-sys",
- "freetype-sys",
- "pkg-config",
 ]
 
 [[package]]
@@ -3450,23 +3202,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "shared_library"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
-dependencies = [
- "lazy_static",
- "libc",
 ]
 
 [[package]]
@@ -3483,9 +3225,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3502,9 +3244,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "siphasher"
@@ -3532,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -3542,15 +3284,15 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "calloop",
  "dlib",
  "lazy_static",
  "log",
- "memmap2",
+ "memmap2 0.5.10",
  "nix 0.24.3",
  "pkg-config",
- "wayland-client",
+ "wayland-client 0.29.5",
  "wayland-cursor",
  "wayland-protocols",
 ]
@@ -3562,7 +3304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a345c870a1fae0b1b779085e81b51e614767c239e93503588e54c5b17f4b0e8"
 dependencies = [
  "smithay-client-toolkit",
- "wayland-client",
+ "wayland-client 0.29.5",
 ]
 
 [[package]]
@@ -3573,6 +3315,34 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "softbuffer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b953f6ba7285f0af131eb748aabd8ddaf53e0b81dda3ba5d803b0847d6559f"
+dependencies = [
+ "bytemuck",
+ "cfg_aliases",
+ "cocoa",
+ "core-graphics",
+ "fastrand 1.9.0",
+ "foreign-types",
+ "log",
+ "nix 0.26.2",
+ "objc",
+ "raw-window-handle 0.5.2",
+ "redox_syscall 0.3.5",
+ "thiserror",
+ "wasm-bindgen",
+ "wayland-backend",
+ "wayland-client 0.30.2",
+ "wayland-sys 0.30.1",
+ "web-sys",
+ "windows-sys 0.48.0",
+ "x11-dl",
+ "x11rb 0.11.1",
 ]
 
 [[package]]
@@ -3587,7 +3357,7 @@ version = "0.2.0+1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "num-traits",
 ]
 
@@ -3617,6 +3387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,6 +3411,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
+name = "swash"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7c73c813353c347272919aa1af2885068b05e625e5532b43049e4f641ae77f"
+dependencies = [
+ "yazi",
+ "zeno",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3647,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3657,14 +3443,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.6.0"
+name = "sys-locale"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "ea0b9eefabb91675082b41eb94c3ecd91af7656caee3fb4961a07c0ec8c7ca6f"
 dependencies = [
- "autocfg",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.48.0",
@@ -3687,22 +3482,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3728,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "serde",
  "time-core",
@@ -3744,27 +3539,53 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "tiny-skia"
-version = "0.7.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642680569bb895b16e4b9d181c60be1ed136fa0c9c7f11d004daf053ba89bf82"
+checksum = "df8493a203431061e901613751931f047d1971337153f96d0e5e363d6dbf6a67"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec",
  "bytemuck",
  "cfg-if",
  "png",
- "safe_arch",
- "tiny-skia-path",
+ "tiny-skia-path 0.8.4",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db11798945fa5c3e5490c794ccca7c6de86d3afdd54b4eb324109939c6f37bc"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path 0.10.0",
 ]
 
 [[package]]
 name = "tiny-skia-path"
-version = "0.7.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c114d32f0c2ee43d585367cb013dfaba967ab9f62b90d9af0d696e955e70fa6c"
+checksum = "adbfb5d3f3dd57a0e11d12f4f13d4ebbbc1b5c15b7ab0a156d030b21da5f677c"
 dependencies = [
  "arrayref",
  "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f60aa35c89ac2687ace1a2556eaaea68e8c0d47408a2e3e7f5c98a489e7281c"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -3793,11 +3614,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -3816,7 +3638,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3854,17 +3676,17 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "toml_datetime",
  "winnow",
 ]
@@ -3903,9 +3725,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "ttf-parser"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dcf002ae3b32cd25400d6df128c5babec3927cd1eb7ce813cfff20eb6c3746"
+checksum = "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33"
 
 [[package]]
 name = "twox-hash"
@@ -3935,9 +3757,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unic-langid"
@@ -3964,10 +3786,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.9"
+name = "unicode-bidi-mirroring"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
+
+[[package]]
+name = "unicode-general-category"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -3977,6 +3823,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-script"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4043,11 +3895,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -4084,7 +3935,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
  "wasm-bindgen-shared",
 ]
 
@@ -4118,7 +3969,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4145,19 +3996,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b48e27457e8da3b2260ac60d0a94512f5cba36448679f3747c0865b7893ed8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "io-lifetimes",
+ "nix 0.26.2",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys 0.30.1",
+]
+
+[[package]]
 name = "wayland-client"
 version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "downcast-rs",
  "libc",
  "nix 0.24.3",
  "scoped-tls",
  "wayland-commons",
- "wayland-scanner",
- "wayland-sys",
+ "wayland-scanner 0.29.5",
+ "wayland-sys 0.29.5",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489c9654770f674fc7e266b3c579f4053d7551df0ceb392f153adb1f9ed06ac8"
+dependencies = [
+ "bitflags 1.3.2",
+ "nix 0.26.2",
+ "wayland-backend",
+ "wayland-scanner 0.30.1",
 ]
 
 [[package]]
@@ -4169,7 +4047,7 @@ dependencies = [
  "nix 0.24.3",
  "once_cell",
  "smallvec",
- "wayland-sys",
+ "wayland-sys 0.29.5",
 ]
 
 [[package]]
@@ -4179,18 +4057,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
 dependencies = [
  "nix 0.24.3",
- "wayland-client",
+ "wayland-client 0.29.5",
  "xcursor",
-]
-
-[[package]]
-name = "wayland-egl"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402de949f81a012926d821a2d659f930694257e76dd92b6e0042ceb27be4107d"
-dependencies = [
- "wayland-client",
- "wayland-sys",
 ]
 
 [[package]]
@@ -4199,10 +4067,10 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
 dependencies = [
- "bitflags",
- "wayland-client",
+ "bitflags 1.3.2",
+ "wayland-client 0.29.5",
  "wayland-commons",
- "wayland-scanner",
+ "wayland-scanner 0.29.5",
 ]
 
 [[package]]
@@ -4217,6 +4085,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-scanner"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b873b257fbc32ec909c0eb80dea312076a67014e65e245f5eb69a6b8ab330e"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
 name = "wayland-sys"
 version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,6 +4103,18 @@ checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
 dependencies = [
  "dlib",
  "lazy_static",
+ "pkg-config",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b2a02ac608e07132978689a6f9bf4214949c85998c247abadd4f4129b1aa06"
+dependencies = [
+ "dlib",
+ "lazy_static",
+ "log",
  "pkg-config",
 ]
 
@@ -4268,11 +4159,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.15.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d745a1b6d91d85c33defbb29f0eee0450e1d2614d987e14bf6baf26009d132d7"
+checksum = "480c965c9306872eb6255fa55e4b4953be55a8b64d57e61d7ff840d3dcc051cd"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec",
  "cfg-if",
  "js-sys",
  "log",
@@ -4292,20 +4183,20 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.15.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7131408d940e335792645a98f03639573b0480e9e2e7cddbbab74f7c6d9f3fff"
+checksum = "8f478237b4bf0d5b70a39898a66fa67ca3a007d79f2520485b8b0c3dfc46f8c2"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec",
  "bit-vec",
- "bitflags",
+ "bitflags 2.3.3",
  "codespan-reporting",
- "fxhash",
  "log",
  "naga",
  "parking_lot 0.12.1",
  "profiling",
  "raw-window-handle 0.5.2",
+ "rustc-hash",
  "smallvec",
  "thiserror",
  "web-sys",
@@ -4315,21 +4206,20 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.15.4"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcf61a283adc744bb5453dd88ea91f3f86d5ca6b027661c6c73c7734ae0288b"
+checksum = "1ecb3258078e936deee14fd4e0febe1cfe9bbb5ffef165cb60218d2ee5eb4448"
 dependencies = [
  "android_system_properties",
- "arrayvec 0.7.3",
+ "arrayvec",
  "ash",
  "bit-set",
- "bitflags",
+ "bitflags 2.3.3",
  "block",
  "core-graphics-types",
  "d3d12",
- "foreign-types 0.3.2",
- "fxhash",
- "glow 0.12.2",
+ "foreign-types",
+ "glow",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
@@ -4337,7 +4227,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.0",
  "log",
  "metal",
  "naga",
@@ -4347,6 +4237,7 @@ dependencies = [
  "range-alloc",
  "raw-window-handle 0.5.2",
  "renderdoc-sys",
+ "rustc-hash",
  "smallvec",
  "thiserror",
  "wasm-bindgen",
@@ -4357,25 +4248,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32444e121b0bd00cb02c0de32fde457a9491bd44e03e7a5db6df9b1da2f6f110"
+checksum = "d0c153280bb108c2979eb5c7391cb18c56642dd3c072e55f52065e13e2a1252a"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "js-sys",
  "web-sys",
-]
-
-[[package]]
-name = "wgpu_glyph"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25440d5f32ec39de49c57c15c2d3f9133a7939b069b5ad07e5afd8b78fb8adc"
-dependencies = [
- "bytemuck",
- "glyph_brush",
- "log",
- "wgpu",
 ]
 
 [[package]]
@@ -4391,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c70234412ca409cc04e864e89523cb0fc37f5e1344ebed5a3ebf4192b6b9f68"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 dependencies = [
  "wasm-bindgen",
  "web-sys",
@@ -4401,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.5.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -4447,15 +4326,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "window_clipboard"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015dd4474dc6aa96fe19aae3a24587a088bd90331dba5a5cc60fb3a180234c4d"
+checksum = "63287c9c4396ccf5346d035a9b0fcaead9e18377637f5eaa78b7ac65c873ff7d"
 dependencies = [
  "clipboard-win",
  "clipboard_macos",
  "clipboard_wayland",
  "clipboard_x11",
- "raw-window-handle 0.3.4",
+ "raw-window-handle 0.5.2",
  "thiserror",
 ]
 
@@ -4474,20 +4353,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -4505,7 +4371,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -4525,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -4552,12 +4418,6 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
@@ -4567,12 +4427,6 @@ name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4588,12 +4442,6 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
@@ -4603,12 +4451,6 @@ name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4636,12 +4478,6 @@ checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
@@ -4654,12 +4490,13 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winit"
-version = "0.27.5"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb796d6fbd86b2fd896c9471e6f04d39d750076ebe5680a3958f00f5ab97657c"
+checksum = "866db3f712fffba75d31bf0cdecf357c8aeafd158c5b7ab51dba2a2b2d47f196"
 dependencies = [
- "bitflags",
- "cocoa",
+ "android-activity",
+ "bitflags 1.3.2",
+ "cfg_aliases",
  "core-foundation",
  "core-graphics",
  "dispatch",
@@ -4668,28 +4505,29 @@ dependencies = [
  "log",
  "mio",
  "ndk",
- "ndk-glue",
- "objc",
+ "objc2",
  "once_cell",
- "parking_lot 0.12.1",
+ "orbclient",
  "percent-encoding",
- "raw-window-handle 0.4.3",
  "raw-window-handle 0.5.2",
+ "redox_syscall 0.3.5",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "wasm-bindgen",
- "wayland-client",
+ "wayland-client 0.29.5",
+ "wayland-commons",
  "wayland-protocols",
+ "wayland-scanner 0.29.5",
  "web-sys",
- "windows-sys 0.36.1",
+ "windows-sys 0.45.0",
  "x11-dl",
 ]
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "8bd122eb777186e60c3fdf765a58ac76e41c582f1f535fbf3314434c6b58f3f7"
 dependencies = [
  "memchr",
 ]
@@ -4710,15 +4548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
  "toml",
-]
-
-[[package]]
-name = "wio"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -4745,6 +4574,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf3c79412dd91bae7a7366b8ad1565a85e35dd049affc3a6a2c549e97419617"
+dependencies = [
+ "gethostname",
+ "libc",
+ "libloading 0.7.4",
+ "nix 0.25.1",
+ "once_cell",
+ "winapi",
+ "winapi-wsapoll",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1513b141123073ce54d5bb1d33f801f17508fbd61e02060b1214e96d39c56"
+dependencies = [
+ "nix 0.25.1",
+]
+
+[[package]]
 name = "xcursor"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4754,16 +4608,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "xi-unicode"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
-
-[[package]]
 name = "xml-rs"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
+checksum = "47430998a7b5d499ccee752b41567bc3afc57e1327dc855b1a2aa44ce29b5fa1"
 
 [[package]]
 name = "yaml-rust"
@@ -4779,6 +4627,18 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yazi"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
+
+[[package]]
+name = "zeno"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c110ba09c9b3a43edd4803d570df0da2414fed6e822e22b976a4e3ef50860701"
 
 [[package]]
 name = "zeroize"
@@ -4802,7 +4662,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.22",
+ "time 0.3.23",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ fluent = "0.16.0"
 fuzzy-matcher = "0.3.7"
 globetter = "0.1.1"
 globset = "0.4.10"
-iced = { version = "0.9.0", features = ["default_system_font", "glow", "tokio"] }
-iced_native = { version = "0.10.3" }
-iced_style = "0.8.0"
+iced = { version = "0.10.0", features = ["advanced", "tokio"] }
+# iced_native = { version = "0.10.3" }
+iced_style = "0.9.0"
 image = { version = "0.24.2", features = ["ico"], default-features = false }
 indicatif = { version = "0.16.2", features = ["rayon"] }
 intl-memoizer = "0.5.1"

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -678,7 +678,7 @@ impl Rclone {
 }
 
 pub mod rclone_monitor {
-    use iced_native::{
+    use iced::{
         futures::{channel::mpsc, StreamExt},
         subscription::{self, Subscription},
     };

--- a/src/gui/badge.rs
+++ b/src/gui/badge.rs
@@ -4,7 +4,7 @@ use crate::{
     gui::{
         common::Message,
         style,
-        widget::{Button, Container, Text, Tooltip},
+        widget::{text, Button, Container, Tooltip},
     },
     lang::TRANSLATOR,
     scan::ScanChange,
@@ -95,7 +95,7 @@ impl Badge {
     pub fn view(self) -> Container<'static> {
         Container::new({
             let content = Container::new(
-                Text::new(self.text)
+                text(self.text)
                     .size(14)
                     .horizontal_alignment(alignment::Horizontal::Center)
                     .width(self.width.unwrap_or(Length::Shrink)),

--- a/src/gui/button.rs
+++ b/src/gui/button.rs
@@ -38,16 +38,16 @@ pub fn negative<'a>(content: String, action: Option<Message>) -> Element<'a> {
 }
 
 pub fn add<'a>(action: fn(EditAction) -> Message) -> Element<'a> {
-    template(Icon::AddCircle.as_text(), Some(action(EditAction::Add)), None)
+    template(Icon::AddCircle.text(), Some(action(EditAction::Add)), None)
 }
 
 pub fn add_nested<'a>(action: fn(usize, EditAction) -> Message, parent: usize) -> Element<'a> {
-    template(Icon::AddCircle.as_text(), Some(action(parent, EditAction::Add)), None)
+    template(Icon::AddCircle.text(), Some(action(parent, EditAction::Add)), None)
 }
 
 pub fn remove<'a>(action: fn(EditAction) -> Message, index: usize) -> Element<'a> {
     template(
-        Icon::RemoveCircle.as_text(),
+        Icon::RemoveCircle.text(),
         Some(action(EditAction::Remove(index))),
         Some(style::Button::Negative),
     )
@@ -55,7 +55,7 @@ pub fn remove<'a>(action: fn(EditAction) -> Message, index: usize) -> Element<'a
 
 pub fn remove_nested<'a>(action: fn(usize, EditAction) -> Message, parent: usize, index: usize) -> Element<'a> {
     template(
-        Icon::RemoveCircle.as_text(),
+        Icon::RemoveCircle.text(),
         Some(action(parent, EditAction::Remove(index))),
         Some(style::Button::Negative),
     )
@@ -63,39 +63,35 @@ pub fn remove_nested<'a>(action: fn(usize, EditAction) -> Message, parent: usize
 
 pub fn delete<'a>(action: fn(EditAction) -> Message, index: usize) -> Element<'a> {
     template(
-        Icon::Delete.as_text(),
+        Icon::Delete.text(),
         Some(action(EditAction::Remove(index))),
         Some(style::Button::Negative),
     )
 }
 
 pub fn close<'a>(action: Message) -> Element<'a> {
-    template(
-        Icon::Close.as_text().width(15).size(15),
-        Some(action),
-        Some(style::Button::Negative),
-    )
+    template(Icon::Close.text_small(), Some(action), Some(style::Button::Negative))
 }
 
 pub fn choose_folder<'a>(subject: BrowseSubject, modifiers: &keyboard::Modifiers) -> Element<'a> {
     if modifiers.shift() {
-        template(Icon::OpenInNew.as_text(), Some(Message::OpenDirSubject(subject)), None)
+        template(Icon::OpenInNew.text(), Some(Message::OpenDirSubject(subject)), None)
     } else {
-        template(Icon::FolderOpen.as_text(), Some(Message::BrowseDir(subject)), None)
+        template(Icon::FolderOpen.text(), Some(Message::BrowseDir(subject)), None)
     }
 }
 
 pub fn choose_file<'a>(subject: BrowseFileSubject, modifiers: &keyboard::Modifiers) -> Element<'a> {
     if modifiers.shift() {
-        template(Icon::OpenInNew.as_text(), Some(Message::OpenFileSubject(subject)), None)
+        template(Icon::OpenInNew.text(), Some(Message::OpenFileSubject(subject)), None)
     } else {
-        template(Icon::FolderOpen.as_text(), Some(Message::BrowseFile(subject)), None)
+        template(Icon::FolderOpen.text(), Some(Message::BrowseFile(subject)), None)
     }
 }
 
 pub fn filter<'a>(screen: Screen, open: bool) -> Element<'a> {
     template(
-        Icon::Filter.as_text(),
+        Icon::Filter.text(),
         Some(Message::ToggleSearch { screen }),
         open.then_some(style::Button::Negative),
     )
@@ -104,9 +100,9 @@ pub fn filter<'a>(screen: Screen, open: bool) -> Element<'a> {
 pub fn sort_order<'a>(screen: Screen, reversed: bool) -> Element<'a> {
     template(
         if reversed {
-            Icon::ArrowDownward.as_text()
+            Icon::ArrowDownward.text()
         } else {
-            Icon::ArrowUpward.as_text()
+            Icon::ArrowUpward.text()
         },
         Some(Message::EditedSortReversed {
             screen,
@@ -117,16 +113,16 @@ pub fn sort_order<'a>(screen: Screen, reversed: bool) -> Element<'a> {
 }
 
 pub fn refresh<'a>(action: Message, ongoing: bool) -> Element<'a> {
-    template(Icon::Refresh.as_text(), (!ongoing).then_some(action), None)
+    template(Icon::Refresh.text(), (!ongoing).then_some(action), None)
 }
 
 pub fn search<'a>(action: Message) -> Element<'a> {
-    template(Icon::Search.as_text(), Some(action), None)
+    template(Icon::Search.text(), Some(action), None)
 }
 
 pub fn settings<'a>(open: bool) -> Element<'a> {
     template(
-        Icon::Settings.as_text(),
+        Icon::Settings.text(),
         Some(Message::ToggleBackupSettings),
         open.then_some(style::Button::Negative),
     )
@@ -134,7 +130,7 @@ pub fn settings<'a>(open: bool) -> Element<'a> {
 
 pub fn move_up<'a>(action: fn(EditAction) -> Message, index: usize) -> Element<'a> {
     template(
-        Icon::ArrowUpward.as_text().width(15).size(15),
+        Icon::ArrowUpward.text_small(),
         (index > 0).then(|| action(EditAction::move_up(index))),
         None,
     )
@@ -142,7 +138,7 @@ pub fn move_up<'a>(action: fn(EditAction) -> Message, index: usize) -> Element<'
 
 pub fn move_up_nested<'a>(action: fn(usize, EditAction) -> Message, parent: usize, index: usize) -> Element<'a> {
     template(
-        Icon::ArrowUpward.as_text().width(15).size(15),
+        Icon::ArrowUpward.text_small(),
         (index > 0).then(|| action(parent, EditAction::move_up(index))),
         None,
     )
@@ -150,7 +146,7 @@ pub fn move_up_nested<'a>(action: fn(usize, EditAction) -> Message, parent: usiz
 
 pub fn move_down<'a>(action: fn(EditAction) -> Message, index: usize, max: usize) -> Element<'a> {
     template(
-        Icon::ArrowDownward.as_text().width(15).size(15),
+        Icon::ArrowDownward.text_small(),
         (index < max - 1).then(|| action(EditAction::move_down(index))),
         None,
     )
@@ -163,7 +159,7 @@ pub fn move_down_nested<'a>(
     max: usize,
 ) -> Element<'a> {
     template(
-        Icon::ArrowDownward.as_text().width(15).size(15),
+        Icon::ArrowDownward.text_small(),
         (index < max - 1).then(|| action(parent, EditAction::move_down(index))),
         None,
     )
@@ -171,14 +167,14 @@ pub fn move_down_nested<'a>(
 
 pub fn next_page<'a>(action: fn(usize) -> Message, page: usize, pages: usize) -> Element<'a> {
     template(
-        Icon::ArrowForward.as_text(),
+        Icon::ArrowForward.text(),
         (page < pages).then(|| action(page + 1)),
         None,
     )
 }
 
 pub fn previous_page<'a>(action: fn(usize) -> Message, page: usize) -> Element<'a> {
-    template(Icon::ArrowBack.as_text(), (page > 0).then(|| action(page - 1)), None)
+    template(Icon::ArrowBack.text(), (page > 0).then(|| action(page - 1)), None)
 }
 
 pub fn toggle_all_scanned_games<'a>(all_enabled: bool) -> Element<'a> {
@@ -235,7 +231,7 @@ pub fn nav<'a>(screen: Screen, current_screen: Screen) -> Button<'a> {
 
     Button::new(
         Text::new(text)
-            .size(16)
+            .size(14)
             .horizontal_alignment(alignment::Horizontal::Center),
     )
     .on_press(Message::SwitchScreen(screen))
@@ -249,7 +245,7 @@ pub fn nav<'a>(screen: Screen, current_screen: Screen) -> Button<'a> {
 
 pub fn upload<'a>(operation: &Operation) -> Element<'a> {
     template(
-        Icon::Upload.as_text(),
+        Icon::Upload.text(),
         match operation {
             Operation::Idle => Some(Message::ConfirmSynchronizeCloud {
                 direction: SyncDirection::Upload,
@@ -273,7 +269,7 @@ pub fn upload<'a>(operation: &Operation) -> Element<'a> {
 
 pub fn download<'a>(operation: &Operation) -> Element<'a> {
     template(
-        Icon::Download.as_text(),
+        Icon::Download.text(),
         match operation {
             Operation::Idle => Some(Message::ConfirmSynchronizeCloud {
                 direction: SyncDirection::Download,

--- a/src/gui/button.rs
+++ b/src/gui/button.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         icon::Icon,
         style,
-        widget::{Button, Element, IcedButtonExt, Text},
+        widget::{text, Button, Element, IcedButtonExt, Text},
     },
     lang::TRANSLATOR,
     prelude::{Finality, SyncDirection},
@@ -22,7 +22,7 @@ fn template(content: Text, action: Option<Message>, style: Option<style::Button>
 }
 
 pub fn primary<'a>(content: String, action: Option<Message>) -> Element<'a> {
-    Button::new(Text::new(content).horizontal_alignment(alignment::Horizontal::Center))
+    Button::new(text(content).horizontal_alignment(alignment::Horizontal::Center))
         .on_press_some(action)
         .style(style::Button::Primary)
         .width(125)
@@ -30,7 +30,7 @@ pub fn primary<'a>(content: String, action: Option<Message>) -> Element<'a> {
 }
 
 pub fn negative<'a>(content: String, action: Option<Message>) -> Element<'a> {
-    Button::new(Text::new(content).horizontal_alignment(alignment::Horizontal::Center))
+    Button::new(text(content).horizontal_alignment(alignment::Horizontal::Center))
         .on_press_some(action)
         .style(style::Button::Negative)
         .width(125)
@@ -180,13 +180,13 @@ pub fn previous_page<'a>(action: fn(usize) -> Message, page: usize) -> Element<'
 pub fn toggle_all_scanned_games<'a>(all_enabled: bool) -> Element<'a> {
     if all_enabled {
         template(
-            Text::new(TRANSLATOR.deselect_all_button()).width(125),
+            text(TRANSLATOR.deselect_all_button()).width(125),
             Some(Message::DeselectAllGames),
             None,
         )
     } else {
         template(
-            Text::new(TRANSLATOR.select_all_button()).width(125),
+            text(TRANSLATOR.select_all_button()).width(125),
             Some(Message::SelectAllGames),
             None,
         )
@@ -196,13 +196,13 @@ pub fn toggle_all_scanned_games<'a>(all_enabled: bool) -> Element<'a> {
 pub fn toggle_all_custom_games<'a>(all_enabled: bool) -> Element<'a> {
     if all_enabled {
         template(
-            Text::new(TRANSLATOR.disable_all_button()).width(125),
+            text(TRANSLATOR.disable_all_button()).width(125),
             Some(Message::DeselectAllGames),
             None,
         )
     } else {
         template(
-            Text::new(TRANSLATOR.enable_all_button()).width(125),
+            text(TRANSLATOR.enable_all_button()).width(125),
             Some(Message::SelectAllGames),
             None,
         )
@@ -211,36 +211,32 @@ pub fn toggle_all_custom_games<'a>(all_enabled: bool) -> Element<'a> {
 
 pub fn add_game<'a>() -> Element<'a> {
     template(
-        Text::new(TRANSLATOR.add_game_button()).width(125),
+        text(TRANSLATOR.add_game_button()).width(125),
         Some(Message::EditedCustomGame(EditAction::Add)),
         None,
     )
 }
 
 pub fn open_url<'a>(label: String, url: String) -> Element<'a> {
-    template(Text::new(label).width(125), Some(Message::OpenUrl(url)), None)
+    template(text(label).width(125), Some(Message::OpenUrl(url)), None)
 }
 
 pub fn nav<'a>(screen: Screen, current_screen: Screen) -> Button<'a> {
-    let text = match screen {
+    let label = match screen {
         Screen::Backup => TRANSLATOR.nav_backup_button(),
         Screen::Restore => TRANSLATOR.nav_restore_button(),
         Screen::CustomGames => TRANSLATOR.nav_custom_games_button(),
         Screen::Other => TRANSLATOR.nav_other_button(),
     };
 
-    Button::new(
-        Text::new(text)
-            .size(14)
-            .horizontal_alignment(alignment::Horizontal::Center),
-    )
-    .on_press(Message::SwitchScreen(screen))
-    .padding([5, 20, 5, 20])
-    .style(if current_screen == screen {
-        style::Button::NavButtonActive
-    } else {
-        style::Button::NavButtonInactive
-    })
+    Button::new(text(label).size(14).horizontal_alignment(alignment::Horizontal::Center))
+        .on_press(Message::SwitchScreen(screen))
+        .padding([5, 20, 5, 20])
+        .style(if current_screen == screen {
+            style::Button::NavButtonActive
+        } else {
+            style::Button::NavButtonInactive
+        })
 }
 
 pub fn upload<'a>(operation: &Operation) -> Element<'a> {
@@ -293,7 +289,7 @@ pub fn download<'a>(operation: &Operation) -> Element<'a> {
 
 pub fn backup<'a>(ongoing: &Operation) -> Element<'a> {
     template(
-        Text::new(match ongoing {
+        text(match ongoing {
             Operation::Backup {
                 finality: Finality::Final,
                 cancelling: false,
@@ -330,7 +326,7 @@ pub fn backup<'a>(ongoing: &Operation) -> Element<'a> {
 
 pub fn backup_preview<'a>(ongoing: &Operation) -> Element<'a> {
     template(
-        Text::new(match ongoing {
+        text(match ongoing {
             Operation::Backup {
                 finality: Finality::Preview,
                 cancelling: false,
@@ -371,7 +367,7 @@ pub fn backup_preview<'a>(ongoing: &Operation) -> Element<'a> {
 
 pub fn restore<'a>(ongoing: &Operation) -> Element<'a> {
     template(
-        Text::new(match ongoing {
+        text(match ongoing {
             Operation::Restore {
                 finality: Finality::Final,
                 cancelling: false,
@@ -408,7 +404,7 @@ pub fn restore<'a>(ongoing: &Operation) -> Element<'a> {
 
 pub fn restore_preview<'a>(ongoing: &Operation) -> Element<'a> {
     template(
-        Text::new(match ongoing {
+        text(match ongoing {
             Operation::Restore {
                 finality: Finality::Preview,
                 cancelling: false,
@@ -448,7 +444,7 @@ pub fn restore_preview<'a>(ongoing: &Operation) -> Element<'a> {
 
 pub fn validate_backups<'a>(ongoing: &Operation) -> Element<'a> {
     template(
-        Text::new(match ongoing {
+        text(match ongoing {
             Operation::ValidateBackups { cancelling: false, .. } => TRANSLATOR.cancel_button(),
             Operation::ValidateBackups { cancelling: true, .. } => TRANSLATOR.cancelling_button(),
             _ => TRANSLATOR.validate_button(),

--- a/src/gui/common.rs
+++ b/src/gui/common.rs
@@ -194,7 +194,7 @@ pub enum Message {
     OpenUrlFailure {
         url: String,
     },
-    KeyboardEvent(iced_native::keyboard::Event),
+    KeyboardEvent(iced::keyboard::Event),
     EditedFullRetention(u8),
     EditedDiffRetention(u8),
     SelectedBackupToRestore {
@@ -215,7 +215,7 @@ pub enum Message {
     UndoRedo(crate::gui::undoable::Action, UndoSubject),
     Scroll {
         subject: ScrollSubject,
-        position: iced_native::widget::scrollable::RelativeOffset,
+        position: iced::widget::scrollable::RelativeOffset,
     },
     EditedBackupComment {
         game: String,
@@ -669,7 +669,7 @@ impl ScrollSubject {
         }
     }
 
-    pub fn id(&self) -> iced_native::widget::scrollable::Id {
+    pub fn id(&self) -> iced::widget::scrollable::Id {
         match self {
             Self::Backup => crate::gui::widget::id::backup_scroll(),
             Self::Restore => crate::gui::widget::id::restore_scroll(),
@@ -687,9 +687,9 @@ impl ScrollSubject {
             .height(Length::Fill)
             .style(crate::gui::style::Scrollable)
             .id(self.id())
-            .on_scroll(move |position| Message::Scroll {
+            .on_scroll(move |viewport| Message::Scroll {
                 subject: self,
-                position,
+                position: viewport.relative_offset(),
             })
     }
 }

--- a/src/gui/editor.rs
+++ b/src/gui/editor.rs
@@ -10,7 +10,7 @@ use crate::{
         common::{BackupPhase, BrowseSubject, Message, ScrollSubject, UndoSubject},
         shortcuts::TextHistories,
         style,
-        widget::{Checkbox, Column, Container, PickList, Row, Text, Tooltip},
+        widget::{checkbox, pick_list, text, Column, Container, Row, Tooltip},
     },
     lang::TRANSLATOR,
     resource::{
@@ -22,7 +22,7 @@ use crate::{
 pub fn root<'a>(config: &Config, histories: &TextHistories, modifiers: &keyboard::Modifiers) -> Container<'a> {
     let mut content = Column::new().width(Length::Fill).spacing(5);
     if config.roots.is_empty() {
-        content = content.push(Text::new(TRANSLATOR.no_roots_are_configured()));
+        content = content.push(text(TRANSLATOR.no_roots_are_configured()));
     } else {
         content = config.roots.iter().enumerate().fold(content, |parent, (i, root)| {
             parent.push(
@@ -32,7 +32,7 @@ pub fn root<'a>(config: &Config, histories: &TextHistories, modifiers: &keyboard
                     .push(button::move_down(Message::EditedRoot, i, config.roots.len()))
                     .push(histories.input(UndoSubject::Root(i)))
                     .push(
-                        PickList::new(Store::ALL, Some(root.store), move |v| Message::SelectedRootStore(i, v))
+                        pick_list(Store::ALL, Some(root.store), move |v| Message::SelectedRootStore(i, v))
                             .style(style::PickList::Primary),
                     )
                     .push(button::choose_folder(BrowseSubject::Root(i), modifiers))
@@ -70,7 +70,7 @@ pub fn redirect<'a>(config: &Config, histories: &TextHistories, modifiers: &keyb
                             config.redirects.len(),
                         ))
                         .push(
-                            PickList::new(RedirectKind::ALL, Some(redirects[i].kind), move |v| {
+                            pick_list(RedirectKind::ALL, Some(redirects[i].kind), move |v| {
                                 Message::SelectedRedirectKind(i, v)
                             })
                             .style(style::PickList::Primary),
@@ -117,7 +117,7 @@ pub fn custom_games<'a>(
                                         .spacing(20)
                                         .align_items(Alignment::Center)
                                         .push(
-                                            Checkbox::new("", config.is_custom_game_enabled(i), move |enabled| {
+                                            checkbox("", config.is_custom_game_enabled(i), move |enabled| {
                                                 Message::ToggleCustomGameEnabled { index: i, enabled }
                                             })
                                             .spacing(0)
@@ -152,11 +152,7 @@ pub fn custom_games<'a>(
                         )
                         .push(
                             Row::new()
-                                .push(
-                                    Column::new()
-                                        .width(130)
-                                        .push(Text::new(TRANSLATOR.custom_files_label())),
-                                )
+                                .push(Column::new().width(130).push(text(TRANSLATOR.custom_files_label())))
                                 .push(
                                     x.files
                                         .iter()
@@ -186,11 +182,7 @@ pub fn custom_games<'a>(
                         )
                         .push(
                             Row::new()
-                                .push(
-                                    Column::new()
-                                        .width(130)
-                                        .push(Text::new(TRANSLATOR.custom_registry_label())),
-                                )
+                                .push(Column::new().width(130).push(text(TRANSLATOR.custom_registry_label())))
                                 .push(
                                     x.registry
                                         .iter()
@@ -240,11 +232,7 @@ pub fn ignored_items<'a>(config: &Config, histories: &TextHistories, modifiers: 
                     .spacing(5)
                     .push(
                         Row::new()
-                            .push(
-                                Column::new()
-                                    .width(100)
-                                    .push(Text::new(TRANSLATOR.custom_files_label())),
-                            )
+                            .push(Column::new().width(100).push(text(TRANSLATOR.custom_files_label())))
                             .push(
                                 config
                                     .backup
@@ -275,11 +263,7 @@ pub fn ignored_items<'a>(config: &Config, histories: &TextHistories, modifiers: 
                     )
                     .push(
                         Row::new()
-                            .push(
-                                Column::new()
-                                    .width(100)
-                                    .push(Text::new(TRANSLATOR.custom_registry_label())),
-                            )
+                            .push(Column::new().width(100).push(text(TRANSLATOR.custom_registry_label())))
                             .push(
                                 config
                                     .backup

--- a/src/gui/editor.rs
+++ b/src/gui/editor.rs
@@ -1,5 +1,8 @@
-use iced::{keyboard, widget::Space, Alignment, Length};
-use iced_native::widget::tooltip;
+use iced::{
+    keyboard,
+    widget::{tooltip, Space},
+    Alignment, Length,
+};
 
 use crate::{
     gui::{

--- a/src/gui/file_tree.rs
+++ b/src/gui/file_tree.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
-use iced::{Alignment, Length};
+use iced::Alignment;
 
 use crate::{
     gui::{
@@ -150,10 +150,10 @@ impl FileTreeNode {
                     .spacing(10)
                     .push(match self.node_type {
                         FileTreeNodeType::File | FileTreeNodeType::RegistryValue(_) => {
-                            Container::new(Icon::SubdirectoryArrowRight.as_text().height(25).width(25).size(25))
+                            Container::new(Icon::SubdirectoryArrowRight.text().height(25).width(25).size(25))
                         }
                         FileTreeNodeType::RegistryKey => Container::new(
-                            Button::new(Icon::KeyboardArrowDown.into_text().width(15).size(15))
+                            Button::new(Icon::KeyboardArrowDown.text_small())
                                 .style(style::Button::Primary)
                                 .height(25)
                                 .width(25),
@@ -222,9 +222,7 @@ impl FileTreeNode {
                                 } else {
                                     Icon::KeyboardArrowRight
                                 })
-                                .into_text()
-                                .width(15)
-                                .size(15),
+                                .text_small(),
                             )
                             .on_press(Message::ToggleGameListEntryTreeExpanded {
                                 name: game_name.to_string(),
@@ -245,7 +243,7 @@ impl FileTreeNode {
                         .push_some(|| {
                             if let FileTreeNodePath::File(path) = &self.path {
                                 return Some(
-                                    Button::new(Icon::OpenInNew.as_text().width(Length::Shrink).size(15))
+                                    Button::new(Icon::OpenInNew.text_small())
                                         .on_press(Message::OpenDir { path: path.clone() })
                                         .style(style::Button::Primary)
                                         .height(25),

--- a/src/gui/file_tree.rs
+++ b/src/gui/file_tree.rs
@@ -8,7 +8,7 @@ use crate::{
         common::{Message, TreeNodeKey},
         icon::Icon,
         style,
-        widget::{Button, Checkbox, Column, Container, IcedParentExt, Row, Text},
+        widget::{checkbox, text, Button, Column, Container, IcedParentExt, Row},
     },
     lang::TRANSLATOR,
     path::StrictPath,
@@ -112,7 +112,7 @@ impl FileTreeNode {
             let path = self.path.clone();
             Some(
                 Container::new(
-                    Checkbox::new("", !self.ignored, move |enabled| match &path {
+                    checkbox("", !self.ignored, move |enabled| match &path {
                         FileTreeNodePath::File(path) => Message::ToggleSpecificGamePathIgnored {
                             name: game_name.clone(),
                             path: path.clone(),
@@ -160,7 +160,7 @@ impl FileTreeNode {
                         ),
                     })
                     .push_some(make_enabler)
-                    .push(Text::new(label))
+                    .push(text(label))
                     .push_some(|| {
                         let badge = match self.change {
                             ScanChange::Same | ScanChange::Unknown => return None,
@@ -233,13 +233,11 @@ impl FileTreeNode {
                             .width(25),
                         )
                         .push_some(make_enabler)
-                        .push(Text::new(
-                            if label.is_empty() && self.node_type == FileTreeNodeType::File {
-                                "/".to_string()
-                            } else {
-                                label
-                            },
-                        ))
+                        .push(text(if label.is_empty() && self.node_type == FileTreeNodeType::File {
+                            "/".to_string()
+                        } else {
+                            label
+                        }))
                         .push_some(|| {
                             if let FileTreeNodePath::File(path) = &self.path {
                                 return Some(

--- a/src/gui/game_list.rs
+++ b/src/gui/game_list.rs
@@ -164,7 +164,7 @@ impl GameListEntry {
                                 .and_then(|backup| backup.comment().as_ref())
                                 .map(|comment| {
                                     Tooltip::new(
-                                        Icon::Comment.as_text().width(Length::Shrink),
+                                        Icon::Comment.text().width(Length::Shrink),
                                         comment,
                                         tooltip::Position::Top,
                                     )
@@ -183,9 +183,10 @@ impl GameListEntry {
                                 })
                         })
                         .push_some(|| {
-                            self.scan_info.backup.as_ref().and_then(|backup| {
-                                backup.locked().then_some(Icon::Lock.into_text().width(Length::Shrink))
-                            })
+                            self.scan_info
+                                .backup
+                                .as_ref()
+                                .and_then(|backup| backup.locked().then_some(Icon::Lock.text().width(Length::Shrink)))
                         })
                         .push(
                             Row::new()
@@ -249,7 +250,7 @@ impl GameListEntry {
                                         None
                                     };
                                     if let Some(action) = action {
-                                        let button = Button::new(action.icon().into_text().width(45))
+                                        let button = Button::new(action.icon().text().width(45))
                                             .on_press_if(
                                                 || !operating,
                                                 || Message::GameAction {

--- a/src/gui/game_list.rs
+++ b/src/gui/game_list.rs
@@ -13,7 +13,7 @@ use crate::{
         shortcuts::TextHistories,
         style,
         widget::{
-            Button, Checkbox, Column, Container, IcedButtonExt, IcedParentExt, PickList, Row, Text, TextInput, Tooltip,
+            checkbox, pick_list, text, Button, Column, Container, IcedButtonExt, IcedParentExt, Row, TextInput, Tooltip,
         },
     },
     lang::TRANSLATOR,
@@ -78,7 +78,7 @@ impl GameListEntry {
                         .spacing(15)
                         .align_items(Alignment::Center)
                         .push(
-                            Checkbox::new("", enabled, move |enabled| Message::ToggleGameListEntryEnabled {
+                            checkbox("", enabled, move |enabled| Message::ToggleGameListEntryEnabled {
                                 name: name_for_checkbox.clone(),
                                 enabled,
                                 restoring,
@@ -88,7 +88,7 @@ impl GameListEntry {
                         )
                         .push(
                             Button::new(
-                                Text::new(self.scan_info.game_name.clone())
+                                text(self.scan_info.game_name.clone())
                                     .horizontal_alignment(HorizontalAlignment::Center),
                             )
                             .on_press_some(if self.scanned {
@@ -193,7 +193,7 @@ impl GameListEntry {
                                 .push_some(|| {
                                     if self.scan_info.available_backups.len() == 1 {
                                         self.scan_info.backup.as_ref().map(|backup| {
-                                            Container::new(Text::new(backup.label()).size(18))
+                                            Container::new(text(backup.label()).size(18))
                                                 .padding([2, 0, 0, 0])
                                                 .width(165)
                                                 .align_x(HorizontalAlignment::Center)
@@ -201,7 +201,7 @@ impl GameListEntry {
                                     } else if !self.scan_info.available_backups.is_empty() {
                                         if operating {
                                             return self.scan_info.backup.as_ref().map(|backup| {
-                                                Container::new(Text::new(backup.label()).size(15))
+                                                Container::new(text(backup.label()).size(15))
                                                     .padding(2)
                                                     .width(165)
                                                     .height(25)
@@ -213,7 +213,7 @@ impl GameListEntry {
 
                                         let game = self.scan_info.game_name.clone();
                                         let content = Container::new(
-                                            PickList::new(
+                                            pick_list(
                                                 &self.scan_info.available_backups,
                                                 self.scan_info.backup.as_ref().cloned(),
                                                 move |backup| Message::SelectedBackupToRestore {
@@ -292,7 +292,7 @@ impl GameListEntry {
                                     }
                                 })
                                 .push(
-                                    Container::new(Text::new({
+                                    Container::new(text({
                                         let summed = self.scan_info.sum_bytes(self.backup_info.as_ref());
                                         if summed == 0 && !self.scan_info.found_anything() {
                                             "".to_string()
@@ -321,7 +321,7 @@ impl GameListEntry {
                             .align_items(Alignment::Center)
                             .padding([0, 20])
                             .spacing(20)
-                            .push(Text::new(TRANSLATOR.comment_label()))
+                            .push(text(TRANSLATOR.comment_label()))
                             .push(
                                 TextInput::new(&TRANSLATOR.comment_label(), comment).on_input(move |value| {
                                     Message::EditedBackupComment {

--- a/src/gui/icon.rs
+++ b/src/gui/icon.rs
@@ -1,6 +1,6 @@
 use iced::{alignment, font, Font};
 
-use crate::gui::widget::Text;
+use crate::gui::widget::{text, Text};
 
 pub const ICONS_DATA: &[u8] = include_bytes!("../../assets/MaterialIcons-Regular.ttf");
 // pub const ICONS: Font = Font::External {
@@ -86,7 +86,7 @@ impl Icon {
     }
 
     pub fn text(self) -> Text<'static> {
-        Text::new(self.as_char().to_string())
+        text(self.as_char().to_string())
             .font(ICONS)
             .size(20)
             .width(60)
@@ -97,7 +97,7 @@ impl Icon {
     }
 
     pub fn text_small(self) -> Text<'static> {
-        Text::new(self.as_char().to_string())
+        text(self.as_char().to_string())
             .font(ICONS)
             .size(15)
             .width(15)

--- a/src/gui/icon.rs
+++ b/src/gui/icon.rs
@@ -1,10 +1,19 @@
-use iced::{alignment::Horizontal as HorizontalAlignment, Font};
+use iced::{alignment, font, Font};
 
 use crate::gui::widget::Text;
 
-pub const ICONS: Font = Font::External {
-    name: "Material Icons",
-    bytes: include_bytes!("../../assets/MaterialIcons-Regular.ttf"),
+pub const ICONS_DATA: &[u8] = include_bytes!("../../assets/MaterialIcons-Regular.ttf");
+// pub const ICONS: Font = Font::External {
+//     name: "Material Icons",
+//     bytes: include_bytes!("../../assets/MaterialIcons-Regular.ttf"),
+// };
+pub const ICONS: Font = Font {
+    // name: "Material Icons",
+    // bytes: include_bytes!("../../assets/MaterialIcons-Regular.ttf"),
+    family: font::Family::Name("Material Icons"),
+    weight: font::Weight::Normal,
+    stretch: font::Stretch::Normal,
+    monospaced: false,
 };
 
 pub enum Icon {
@@ -76,17 +85,25 @@ impl Icon {
         }
     }
 
-    pub fn as_text(&self) -> Text {
+    pub fn text(self) -> Text<'static> {
         Text::new(self.as_char().to_string())
             .font(ICONS)
+            .size(20)
             .width(60)
-            .horizontal_alignment(HorizontalAlignment::Center)
+            .height(20)
+            .horizontal_alignment(alignment::Horizontal::Center)
+            .vertical_alignment(iced::alignment::Vertical::Center)
+            .line_height(1.0)
     }
 
-    pub fn into_text(self) -> Text<'static> {
+    pub fn text_small(self) -> Text<'static> {
         Text::new(self.as_char().to_string())
             .font(ICONS)
-            .width(60)
-            .horizontal_alignment(HorizontalAlignment::Center)
+            .size(15)
+            .width(15)
+            .height(15)
+            .horizontal_alignment(alignment::Horizontal::Center)
+            .vertical_alignment(iced::alignment::Vertical::Center)
+            .line_height(1.0)
     }
 }

--- a/src/gui/modal.rs
+++ b/src/gui/modal.rs
@@ -11,7 +11,7 @@ use crate::{
         common::{BackupPhase, Message, RestorePhase, ScrollSubject, UndoSubject},
         shortcuts::TextHistories,
         style,
-        widget::{Column, Container, Element, IcedParentExt, PickList, Row, Space, Text},
+        widget::{pick_list, text, Column, Container, Element, IcedParentExt, Row, Space},
     },
     lang::TRANSLATOR,
     prelude::{Error, Finality, SyncDirection},
@@ -57,7 +57,7 @@ impl ModalField {
 
         Row::new()
             .align_items(Alignment::Center)
-            .push(Text::new(label).width(150))
+            .push(text(label).width(150))
             .push(histories.input(UndoSubject::ModalField(kind)))
     }
 
@@ -67,9 +67,9 @@ impl ModalField {
     {
         Row::new()
             .align_items(Alignment::Center)
-            .push(Text::new(label).width(150))
+            .push(text(label).width(150))
             .push(
-                Container::new(PickList::new(choices, Some(*value), move |x| {
+                Container::new(pick_list(choices, Some(*value), move |x| {
                     Message::EditedModalField(change(x))
                 }))
                 .width(Length::Fill),
@@ -331,7 +331,7 @@ impl Modal {
             .spacing(15)
             .padding([0, 10, 0, 0])
             .align_items(Alignment::Center)
-            .push(Text::new(self.text(config)));
+            .push(text(self.text(config)));
 
         match self {
             Self::Error { .. }
@@ -344,7 +344,7 @@ impl Modal {
             | Self::UpdatingManifest => (),
             Self::BackupValidation { games } => {
                 for game in games.iter().sorted() {
-                    col = col.push(Text::new(game))
+                    col = col.push(text(game))
                 }
             }
             modal @ Self::ConfirmCloudSync {
@@ -363,8 +363,8 @@ impl Modal {
                                 Row::new()
                                     .spacing(20)
                                     .align_items(Alignment::Center)
-                                    .push(Text::new(TRANSLATOR.change_count_label(changes.len())))
-                                    .push_if(|| changes.is_empty() && !done, || Text::new(TRANSLATOR.loading()))
+                                    .push(text(TRANSLATOR.change_count_label(changes.len())))
+                                    .push_if(|| changes.is_empty() && !done, || text(TRANSLATOR.loading()))
                                     .push(Space::new(Length::Fill, Length::Shrink))
                                     .push(button::previous_page(Message::ModalChangePage, *page))
                                     .push(button::next_page(
@@ -387,7 +387,7 @@ impl Modal {
                                                 .spacing(20)
                                                 .align_items(Alignment::Start)
                                                 .push(Badge::scan_change(*change).view())
-                                                .push(Text::new(path)),
+                                                .push(text(path)),
                                         )
                                     },
                                 ),

--- a/src/gui/notification.rs
+++ b/src/gui/notification.rs
@@ -4,7 +4,7 @@ use iced::alignment;
 
 use crate::gui::{
     style,
-    widget::{Container, Text},
+    widget::{text, Container},
 };
 
 pub struct Notification {
@@ -36,7 +36,7 @@ impl Notification {
 
     pub fn view(&self) -> Container<'static> {
         Container::new(
-            Container::new(Text::new(self.text.clone()))
+            Container::new(text(self.text.clone()))
                 .padding([3, 40])
                 .align_x(alignment::Horizontal::Center)
                 .align_y(alignment::Vertical::Center)

--- a/src/gui/popup_menu.rs
+++ b/src/gui/popup_menu.rs
@@ -433,6 +433,7 @@ where
         // .width(bounds.width.round() as u16)
         .padding(padding)
         .font(font)
+        .text_shaping(text::Shaping::Advanced)
         .style(style);
 
         if let Some(text_size) = text_size {

--- a/src/gui/popup_menu.rs
+++ b/src/gui/popup_menu.rs
@@ -4,19 +4,27 @@
 //! Display a dropdown list of selectable values.
 use std::borrow::Cow;
 
-use iced_native::{
+use iced::{
+    advanced::{
+        self, layout, overlay, renderer, text,
+        widget::tree::{self, Tree},
+        Clipboard, Layout, Shell, Widget,
+    },
     alignment,
     event::{self, Event},
-    layout, mouse, overlay,
-    overlay::menu::{self, Menu},
-    renderer,
-    text::{self, Text},
+    mouse,
+    // widget::text::Text,
     touch,
     widget::{
-        container, scrollable,
-        tree::{self, Tree},
+        container,
+        overlay::menu::{self, Menu},
+        scrollable,
     },
-    Clipboard, Element, Layout, Length, Padding, Point, Rectangle, Shell, Size, Widget,
+    Element,
+    Length,
+    Padding,
+    Rectangle,
+    Size,
 };
 pub use iced_style::pick_list::{Appearance, StyleSheet};
 
@@ -35,7 +43,7 @@ where
     width: Length,
     padding: Padding,
     text_size: Option<f32>,
-    font: Renderer::Font,
+    font: Option<Renderer::Font>,
     style: <Renderer::Theme as StyleSheet>::Style,
 }
 
@@ -65,7 +73,7 @@ where
             width: Length::Shrink,
             text_size: None,
             padding: Self::DEFAULT_PADDING,
-            font: Default::default(),
+            font: None,
             style: Default::default(),
         }
     }
@@ -139,7 +147,7 @@ where
             self.width,
             self.padding,
             self.text_size,
-            &self.font,
+            self.font,
             // self.placeholder.as_deref(),
             // &self.options,
         )
@@ -150,15 +158,16 @@ where
         tree: &mut Tree,
         event: Event,
         layout: Layout<'_>,
-        cursor_position: Point,
+        cursor: mouse::Cursor,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         update(
             event,
             layout,
-            cursor_position,
+            cursor,
             shell,
             self.on_selected.as_ref(),
             // self.selected.as_ref(),
@@ -172,11 +181,11 @@ where
         &self,
         _tree: &Tree,
         layout: Layout<'_>,
-        cursor_position: Point,
+        cursor: mouse::Cursor,
         _viewport: &Rectangle,
         _renderer: &Renderer,
     ) -> mouse::Interaction {
-        mouse_interaction(layout, cursor_position, !self.options.is_empty())
+        mouse_interaction(layout, cursor, !self.options.is_empty())
     }
 
     fn draw(
@@ -186,14 +195,14 @@ where
         theme: &Renderer::Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
-        cursor_position: Point,
+        cursor: mouse::Cursor,
         _viewport: &Rectangle,
     ) {
         draw(
             renderer,
             theme,
             layout,
-            cursor_position,
+            cursor,
             // self.padding,
             // self.text_size,
             // &self.font,
@@ -207,7 +216,7 @@ where
         &'b mut self,
         tree: &'b mut Tree,
         layout: Layout<'_>,
-        _renderer: &Renderer,
+        renderer: &Renderer,
     ) -> Option<overlay::Element<'b, Message, Renderer>> {
         let state = tree.state.downcast_mut::<State<T>>();
 
@@ -216,8 +225,9 @@ where
             state,
             self.padding,
             self.text_size,
-            self.font,
+            self.font.unwrap_or_else(|| renderer.default_font()),
             &self.options,
+            &self.on_selected,
             self.style.clone(),
         )
     }
@@ -274,7 +284,7 @@ pub fn layout<Renderer>(
     width: Length,
     padding: Padding,
     text_size: Option<f32>,
-    font: &Renderer::Font,
+    font: Option<Renderer::Font>,
     // placeholder: Option<&str>,
     // options: &[T],
 ) -> layout::Node
@@ -290,11 +300,13 @@ where
 
     let max_width = match width {
         Length::Shrink => {
-            let (width, _) = renderer.measure(
+            let Size { width, .. } = renderer.measure(
                 &crate::gui::icon::Icon::MoreVert.as_char().to_string(),
                 text_size,
-                font.clone(),
+                text::LineHeight::default(),
+                font.unwrap_or_else(|| renderer.default_font()),
                 Size::new(f32::INFINITY, f32::INFINITY),
+                text::Shaping::Advanced,
             );
             width.round() as u32
         }
@@ -316,7 +328,7 @@ where
 pub fn update<'a, T, Message>(
     event: Event,
     layout: Layout<'_>,
-    cursor_position: Point,
+    cursor: mouse::Cursor,
     shell: &mut Shell<'_, Message>,
     on_selected: &dyn Fn(T) -> Message,
     selected: Option<&T>,
@@ -337,7 +349,7 @@ where
                 state.is_open = false;
 
                 event::Status::Captured
-            } else if layout.bounds().contains(cursor_position) {
+            } else if cursor.is_over(layout.bounds()) {
                 state.is_open = !options.is_empty();
                 state.hovered_option = options.iter().position(|option| Some(option) == selected);
 
@@ -373,9 +385,9 @@ where
 }
 
 /// Returns the current [`mouse::Interaction`] of a [`PopupMenu`].
-pub fn mouse_interaction(layout: Layout<'_>, cursor_position: Point, usable: bool) -> mouse::Interaction {
+pub fn mouse_interaction(layout: Layout<'_>, cursor: mouse::Cursor, usable: bool) -> mouse::Interaction {
     let bounds = layout.bounds();
-    let is_mouse_over = bounds.contains(cursor_position);
+    let is_mouse_over = cursor.is_over(bounds);
 
     if is_mouse_over && usable {
         mouse::Interaction::Pointer
@@ -392,6 +404,7 @@ pub fn overlay<'a, T, Message, Renderer>(
     text_size: Option<f32>,
     font: Renderer::Font,
     options: &'a [T],
+    on_selected: &'a dyn Fn(T) -> Message,
     style: <Renderer::Theme as StyleSheet>::Style,
 ) -> Option<overlay::Element<'a, Message, Renderer>>
 where
@@ -408,7 +421,13 @@ where
             &mut state.menu,
             options,
             &mut state.hovered_option,
-            &mut state.last_selection,
+            // &mut state.last_selection,
+            |option| {
+                state.is_open = false;
+
+                (on_selected)(option)
+            },
+            None,
         )
         .width(150.0)
         // .width(bounds.width.round() as u16)
@@ -432,7 +451,7 @@ pub fn draw<Renderer>(
     renderer: &mut Renderer,
     theme: &Renderer::Theme,
     layout: Layout<'_>,
-    cursor_position: Point,
+    cursor: mouse::Cursor,
     // padding: Padding,
     // text_size: Option<f32>,
     // font: &Renderer::Font,
@@ -445,7 +464,7 @@ pub fn draw<Renderer>(
     // T: ToString,
 {
     let bounds = layout.bounds();
-    let is_mouse_over = bounds.contains(cursor_position);
+    let is_mouse_over = cursor.is_over(bounds);
     // let is_selected = selected.is_some();
 
     let style = if is_mouse_over {
@@ -460,14 +479,14 @@ pub fn draw<Renderer>(
                 bounds,
                 border_color: style.border_color,
                 border_width: style.border_width,
-                border_radius: renderer::BorderRadius::from(style.border_radius),
+                border_radius: style.border_radius,
             },
             style.background,
         );
     }
 
     let icon_size = 0.5;
-    renderer.fill_text(Text {
+    renderer.fill_text(advanced::Text {
         // content: &Renderer::ARROW_DOWN_ICON.to_string(),
         content: &crate::gui::icon::Icon::MoreVert.as_char().to_string(),
         // font: Renderer::ICON_FONT,
@@ -483,5 +502,7 @@ pub fn draw<Renderer>(
         // horizontal_alignment: alignment::Horizontal::Right,
         horizontal_alignment: alignment::Horizontal::Center,
         vertical_alignment: alignment::Vertical::Center,
+        line_height: text::LineHeight::default(),
+        shaping: text::Shaping::Advanced,
     });
 }

--- a/src/gui/screen.rs
+++ b/src/gui/screen.rs
@@ -13,7 +13,7 @@ use crate::{
         icon::Icon,
         shortcuts::TextHistories,
         style,
-        widget::{number_input, Button, Checkbox, Column, Container, Element, IcedParentExt, PickList, Row, Text},
+        widget::{checkbox, number_input, pick_list, text, Button, Column, Container, Element, IcedParentExt, Row},
     },
     lang::{Language, TRANSLATOR},
     prelude::{AVAILABLE_PARALELLISM, STEAM_DECK},
@@ -43,7 +43,7 @@ fn make_status_row<'a>(status: &OperationStatus, duplication: Duplication) -> Ro
         .padding([0, 20, 0, 20])
         .align_items(Alignment::Center)
         .spacing(15)
-        .push(Text::new(TRANSLATOR.processed_games(status)).size(size))
+        .push(text(TRANSLATOR.processed_games(status)).size(size))
         .push_if(
             || status.changed_games.new > 0,
             || Badge::new_entry_with_count(status.changed_games.new).view(),
@@ -52,8 +52,8 @@ fn make_status_row<'a>(status: &OperationStatus, duplication: Duplication) -> Ro
             || status.changed_games.different > 0,
             || Badge::changed_entry_with_count(status.changed_games.different).view(),
         )
-        .push(Text::new("|").size(size))
-        .push(Text::new(TRANSLATOR.processed_bytes(status)).size(size))
+        .push(text("|").size(size))
+        .push(text(TRANSLATOR.processed_bytes(status)).size(size))
         .push_if(
             || !duplication.resolved(),
             || Badge::new(&TRANSLATOR.badge_duplicates()).view(),
@@ -110,13 +110,13 @@ impl Backup {
                     .padding([0, 20, 0, 20])
                     .spacing(20)
                     .align_items(Alignment::Center)
-                    .push(Text::new(TRANSLATOR.backup_target_label()))
+                    .push(text(TRANSLATOR.backup_target_label()))
                     .push(histories.input(UndoSubject::BackupTarget))
                     .push(button::choose_folder(BrowseSubject::BackupTarget, modifiers))
                     .push("|")
-                    .push(Text::new(TRANSLATOR.sort_label()))
+                    .push(text(TRANSLATOR.sort_label()))
                     .push(
-                        PickList::new(SortKey::ALL, Some(sort.key), move |value| Message::EditedSortKey {
+                        pick_list(SortKey::ALL, Some(sort.key), move |value| Message::EditedSortKey {
                             screen,
                             value,
                         })
@@ -161,9 +161,9 @@ impl Backup {
                             Row::new()
                                 .spacing(5)
                                 .align_items(Alignment::Center)
-                                .push(Text::new(TRANSLATOR.backup_format_field()))
+                                .push(text(TRANSLATOR.backup_format_field()))
                                 .push(
-                                    PickList::new(
+                                    pick_list(
                                         BackupFormat::ALL,
                                         Some(config.backup.format.chosen),
                                         Message::SelectedBackupFormat,
@@ -177,9 +177,9 @@ impl Backup {
                                 Row::new()
                                     .spacing(5)
                                     .align_items(Alignment::Center)
-                                    .push(Text::new(TRANSLATOR.backup_compression_field()))
+                                    .push(text(TRANSLATOR.backup_compression_field()))
                                     .push(
-                                        PickList::new(
+                                        pick_list(
                                             ZipCompression::ALL,
                                             Some(config.backup.format.zip.compression),
                                             Message::SelectedBackupCompression,
@@ -261,13 +261,13 @@ impl Restore {
                     .padding([0, 20, 0, 20])
                     .spacing(20)
                     .align_items(Alignment::Center)
-                    .push(Text::new(TRANSLATOR.restore_source_label()))
+                    .push(text(TRANSLATOR.restore_source_label()))
                     .push(histories.input(UndoSubject::RestoreSource))
                     .push(button::choose_folder(BrowseSubject::RestoreSource, modifiers))
                     .push("|")
-                    .push(Text::new(TRANSLATOR.sort_label()))
+                    .push(text(TRANSLATOR.sort_label()))
                     .push(
-                        PickList::new(SortKey::ALL, Some(sort.key), move |value| Message::EditedSortKey {
+                        pick_list(SortKey::ALL, Some(sort.key), move |value| Message::EditedSortKey {
                             screen,
                             value,
                         })
@@ -331,8 +331,7 @@ pub fn other<'a>(
                     .align_items(iced::Alignment::Center)
                     .push(
                         Button::new(
-                            Text::new(TRANSLATOR.exit_button())
-                                .horizontal_alignment(iced::alignment::Horizontal::Center),
+                            text(TRANSLATOR.exit_button()).horizontal_alignment(iced::alignment::Horizontal::Center),
                         )
                         .on_press(Message::Exit { user: true })
                         .width(125)
@@ -349,9 +348,9 @@ pub fn other<'a>(
                     Row::new()
                         .align_items(iced::Alignment::Center)
                         .spacing(20)
-                        .push(Text::new(TRANSLATOR.field_language()))
+                        .push(text(TRANSLATOR.field_language()))
                         .push(
-                            PickList::new(Language::ALL, Some(config.language), Message::SelectedLanguage)
+                            pick_list(Language::ALL, Some(config.language), Message::SelectedLanguage)
                                 .style(style::PickList::Primary),
                         ),
                 )
@@ -359,14 +358,14 @@ pub fn other<'a>(
                     Row::new()
                         .align_items(iced::Alignment::Center)
                         .spacing(20)
-                        .push(Text::new(TRANSLATOR.field_theme()))
+                        .push(text(TRANSLATOR.field_theme()))
                         .push(
-                            PickList::new(Theme::ALL, Some(config.theme), Message::SelectedTheme)
+                            pick_list(Theme::ALL, Some(config.theme), Message::SelectedTheme)
                                 .style(style::PickList::Primary),
                         ),
                 )
                 .push(
-                    Column::new().spacing(5).push(Text::new(TRANSLATOR.scan_field())).push(
+                    Column::new().spacing(5).push(text(TRANSLATOR.scan_field())).push(
                         Container::new(
                             Column::new()
                                 .padding(5)
@@ -375,7 +374,7 @@ pub fn other<'a>(
                                     AVAILABLE_PARALELLISM.map(|max_threads| {
                                         Column::new()
                                             .spacing(5)
-                                            .push(Checkbox::new(
+                                            .push(checkbox(
                                                 TRANSLATOR.override_max_threads(),
                                                 config.runtime.threads.is_some(),
                                                 Message::OverrideMaxThreads,
@@ -394,24 +393,24 @@ pub fn other<'a>(
                                     })
                                 })
                                 .push(
-                                    Checkbox::new(
+                                    checkbox(
                                         TRANSLATOR.explanation_for_exclude_store_screenshots(),
                                         config.backup.filter.exclude_store_screenshots,
                                         Message::EditedExcludeStoreScreenshots,
                                     )
                                     .style(style::Checkbox),
                                 )
-                                .push(Checkbox::new(
+                                .push(checkbox(
                                     TRANSLATOR.show_deselected_games(),
                                     config.scan.show_deselected_games,
                                     Message::SetShowDeselectedGames,
                                 ))
-                                .push(Checkbox::new(
+                                .push(checkbox(
                                     TRANSLATOR.show_unchanged_games(),
                                     config.scan.show_unchanged_games,
                                     Message::SetShowUnchangedGames,
                                 ))
-                                .push(Checkbox::new(
+                                .push(checkbox(
                                     TRANSLATOR.show_unscanned_games(),
                                     config.scan.show_unscanned_games,
                                     Message::SetShowUnscannedGames,
@@ -426,7 +425,7 @@ pub fn other<'a>(
                         .push(
                             Row::new()
                                 .align_items(iced::Alignment::Center)
-                                .push(Text::new(TRANSLATOR.manifest_label()).width(100))
+                                .push(text(TRANSLATOR.manifest_label()).width(100))
                                 .push(button::refresh(Message::UpdateManifest, updating_manifest)),
                         )
                         .push_some(|| {
@@ -451,14 +450,14 @@ pub fn other<'a>(
                                         .push(
                                             Row::new()
                                                 .align_items(iced::Alignment::Center)
-                                                .push(Container::new(Text::new(TRANSLATOR.checked_label())).width(100))
-                                                .push(Container::new(Text::new(checked))),
+                                                .push(Container::new(text(TRANSLATOR.checked_label())).width(100))
+                                                .push(Container::new(text(checked))),
                                         )
                                         .push(
                                             Row::new()
                                                 .align_items(iced::Alignment::Center)
-                                                .push(Container::new(Text::new(TRANSLATOR.updated_label())).width(100))
-                                                .push(Container::new(Text::new(updated))),
+                                                .push(Container::new(text(TRANSLATOR.updated_label())).width(100))
+                                                .push(Container::new(text(updated))),
                                         ),
                                 )
                                 .style(style::Container::GameListEntry),
@@ -471,7 +470,7 @@ pub fn other<'a>(
                         .push(
                             Row::new()
                                 .align_items(iced::Alignment::Center)
-                                .push(Text::new(TRANSLATOR.cloud_field()).width(100)),
+                                .push(text(TRANSLATOR.cloud_field()).width(100)),
                         )
                         .push(
                             Container::new({
@@ -479,7 +478,7 @@ pub fn other<'a>(
                                     Row::new()
                                         .spacing(20)
                                         .align_items(Alignment::Center)
-                                        .push(Text::new(TRANSLATOR.rclone_label()).width(70))
+                                        .push(text(TRANSLATOR.rclone_label()).width(70))
                                         .push(histories.input(UndoSubject::RcloneExecutable))
                                         .push_if(
                                             || !is_rclone_valid,
@@ -496,11 +495,11 @@ pub fn other<'a>(
                                             let mut row = Row::new()
                                                 .spacing(20)
                                                 .align_items(Alignment::Center)
-                                                .push(Text::new(TRANSLATOR.remote_label()).width(70))
+                                                .push(text(TRANSLATOR.remote_label()).width(70))
                                                 .push_if(
                                                     || !operation.idle(),
                                                     || {
-                                                        Text::new(choice.to_string())
+                                                        text(choice.to_string())
                                                             .height(30)
                                                             .vertical_alignment(iced::alignment::Vertical::Center)
                                                     },
@@ -508,7 +507,7 @@ pub fn other<'a>(
                                                 .push_if(
                                                     || operation.idle(),
                                                     || {
-                                                        PickList::new(
+                                                        pick_list(
                                                             RemoteChoice::ALL,
                                                             Some(choice),
                                                             Message::EditedCloudRemote,
@@ -518,14 +517,14 @@ pub fn other<'a>(
 
                                             if let Some(Remote::Custom { .. }) = &config.cloud.remote {
                                                 row = row
-                                                    .push(Text::new(TRANSLATOR.remote_name_label()))
+                                                    .push(text(TRANSLATOR.remote_name_label()))
                                                     .push(histories.input(UndoSubject::CloudRemoteId));
                                             }
 
                                             if let Some(description) =
                                                 config.cloud.remote.as_ref().and_then(|x| x.description())
                                             {
-                                                row = row.push(Text::new(description));
+                                                row = row.push(text(description));
                                             }
 
                                             row
@@ -536,7 +535,7 @@ pub fn other<'a>(
                                                 Row::new()
                                                     .spacing(20)
                                                     .align_items(Alignment::Center)
-                                                    .push(Text::new(TRANSLATOR.folder_label()).width(70))
+                                                    .push(text(TRANSLATOR.folder_label()).width(70))
                                                     .push(histories.input(UndoSubject::CloudPath))
                                                     .push_if(
                                                         || !is_cloud_path_valid,
@@ -557,28 +556,25 @@ pub fn other<'a>(
                                                     .align_items(Alignment::Center)
                                                     .push(button::upload(operation))
                                                     .push(button::download(operation))
-                                                    .push(Checkbox::new(
+                                                    .push(checkbox(
                                                         TRANSLATOR.synchronize_automatically(),
                                                         config.cloud.synchronize,
                                                         |_| Message::ToggleCloudSynchronize,
                                                     ))
                                             },
                                         )
-                                        .push_if(
-                                            || !is_cloud_configured,
-                                            || Text::new(TRANSLATOR.cloud_not_configured()),
-                                        )
+                                        .push_if(|| !is_cloud_configured, || text(TRANSLATOR.cloud_not_configured()))
                                         .push_if(
                                             || !is_cloud_path_valid,
                                             || {
-                                                Text::new(TRANSLATOR.prefix_warning(&TRANSLATOR.cloud_path_invalid()))
+                                                text(TRANSLATOR.prefix_warning(&TRANSLATOR.cloud_path_invalid()))
                                                     .style(style::Text::Failure)
                                             },
                                         );
                                 } else {
                                     column = column
                                         .push(
-                                            Text::new(TRANSLATOR.prefix_warning(&TRANSLATOR.rclone_unavailable()))
+                                            text(TRANSLATOR.prefix_warning(&TRANSLATOR.rclone_unavailable()))
                                                 .style(style::Text::Failure),
                                         )
                                         .push(button::open_url(TRANSLATOR.get_rclone_button(), RCLONE_URL.to_string()));
@@ -591,7 +587,7 @@ pub fn other<'a>(
                         ),
                 )
                 .push(
-                    Column::new().spacing(5).push(Text::new(TRANSLATOR.roots_label())).push(
+                    Column::new().spacing(5).push(text(TRANSLATOR.roots_label())).push(
                         Container::new(
                             Column::new()
                                 .padding(5)
@@ -603,12 +599,12 @@ pub fn other<'a>(
                 )
                 .push(
                     Column::new()
-                        .push(Text::new(TRANSLATOR.ignored_items_label()))
+                        .push(text(TRANSLATOR.ignored_items_label()))
                         .push(editor::ignored_items(config, histories, modifiers).padding([10, 0, 0, 0])),
                 )
                 .push(
                     Column::new()
-                        .push(Text::new(TRANSLATOR.redirects_label()))
+                        .push(text(TRANSLATOR.redirects_label()))
                         .push(editor::redirect(config, histories, modifiers).padding([10, 0, 0, 0])),
                 );
             ScrollSubject::Other.into_widget(content)

--- a/src/gui/screen.rs
+++ b/src/gui/screen.rs
@@ -37,11 +37,13 @@ fn template(content: Column) -> Element {
 }
 
 fn make_status_row<'a>(status: &OperationStatus, duplication: Duplication) -> Row<'a> {
+    let size = 25;
+
     Row::new()
         .padding([0, 20, 0, 20])
         .align_items(Alignment::Center)
         .spacing(15)
-        .push(Text::new(TRANSLATOR.processed_games(status)).size(35))
+        .push(Text::new(TRANSLATOR.processed_games(status)).size(size))
         .push_if(
             || status.changed_games.new > 0,
             || Badge::new_entry_with_count(status.changed_games.new).view(),
@@ -50,8 +52,8 @@ fn make_status_row<'a>(status: &OperationStatus, duplication: Duplication) -> Ro
             || status.changed_games.different > 0,
             || Badge::changed_entry_with_count(status.changed_games.different).view(),
         )
-        .push(Text::new("|").size(35))
-        .push(Text::new(TRANSLATOR.processed_bytes(status)).size(35))
+        .push(Text::new("|").size(size))
+        .push(Text::new(TRANSLATOR.processed_bytes(status)).size(size))
         .push_if(
             || !duplication.resolved(),
             || Badge::new(&TRANSLATOR.badge_duplicates()).view(),
@@ -481,7 +483,7 @@ pub fn other<'a>(
                                         .push(histories.input(UndoSubject::RcloneExecutable))
                                         .push_if(
                                             || !is_rclone_valid,
-                                            || Icon::Error.as_text().width(Length::Shrink).style(style::Text::Failure),
+                                            || Icon::Error.text().width(Length::Shrink).style(style::Text::Failure),
                                         )
                                         .push(button::choose_file(BrowseFileSubject::RcloneExecutable, modifiers))
                                         .push(histories.input(UndoSubject::RcloneArguments)),
@@ -540,7 +542,7 @@ pub fn other<'a>(
                                                         || !is_cloud_path_valid,
                                                         || {
                                                             Icon::Error
-                                                                .as_text()
+                                                                .text()
                                                                 .width(Length::Shrink)
                                                                 .style(style::Text::Failure)
                                                         },

--- a/src/gui/search.rs
+++ b/src/gui/search.rs
@@ -5,7 +5,7 @@ use crate::{
     gui::{
         common::{Message, Screen, UndoSubject},
         shortcuts::TextHistories,
-        widget::{Checkbox, Column, Element, IcedParentExt, PickList, Row, Text},
+        widget::{checkbox, pick_list, text, Column, Element, IcedParentExt, Row},
     },
     lang::TRANSLATOR,
     scan::{
@@ -40,13 +40,13 @@ fn template<'a, T: 'static + Default + Copy + Eq + PartialEq + ToString>(
         .spacing(10)
         .align_items(Alignment::Center)
         .push(
-            Checkbox::new("", filter.active, move |enabled| Message::ToggledSearchFilter {
+            checkbox("", filter.active, move |enabled| Message::ToggledSearchFilter {
                 filter: kind,
                 enabled,
             })
             .spacing(0),
         )
-        .push(PickList::new(options, Some(filter.choice), message))
+        .push(pick_list(options, Some(filter.choice), message))
         .into()
 }
 
@@ -90,7 +90,7 @@ impl FilterComponent {
                         .padding([0, 20, 10, 20])
                         .spacing(20)
                         .align_items(Alignment::Center)
-                        .push(Text::new(TRANSLATOR.filter_label()))
+                        .push(text(TRANSLATOR.filter_label()))
                         .push(histories.input(match screen {
                             Screen::Restore => UndoSubject::RestoreSearchGameName,
                             _ => UndoSubject::BackupSearchGameName,

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -100,10 +100,10 @@ pub enum Text {
 impl iced::widget::text::StyleSheet for Theme {
     type Style = Text;
 
-    fn appearance(&self, style: Self::Style) -> iced_style::text::Appearance {
+    fn appearance(&self, style: Self::Style) -> iced::widget::text::Appearance {
         match style {
-            Text::Default => iced_style::text::Appearance { color: None },
-            Text::Failure => iced_style::text::Appearance {
+            Text::Default => iced::widget::text::Appearance { color: None },
+            Text::Failure => iced::widget::text::Appearance {
                 color: Some(self.negative),
             },
         }
@@ -122,7 +122,7 @@ impl iced_style::menu::StyleSheet for Theme {
             text_color: self.text,
             selected_background: self.positive.into(),
             border_width: 1.0,
-            border_radius: 5.0,
+            border_radius: 5.0.into(),
             selected_text_color: Color::WHITE,
         }
     }
@@ -171,8 +171,8 @@ impl button::StyleSheet for Theme {
                 | Self::Style::GameListEntryTitleDisabled
                 | Self::Style::GameListEntryTitleUnscanned
                 | Self::Style::NavButtonActive
-                | Self::Style::NavButtonInactive => 10.0,
-                _ => 4.0,
+                | Self::Style::NavButtonInactive => 10.0.into(),
+                _ => 4.0.into(),
             },
             border_width: match style {
                 Self::Style::NavButtonActive | Self::Style::NavButtonInactive => 1.0,
@@ -204,7 +204,7 @@ impl button::StyleSheet for Theme {
                 _ => self.active(style).background,
             },
             border_radius: match style {
-                Self::Style::NavButtonActive | Self::Style::NavButtonInactive => 10.0,
+                Self::Style::NavButtonActive | Self::Style::NavButtonInactive => 10.0.into(),
                 _ => active.border_radius,
             },
             border_width: match style {
@@ -248,14 +248,14 @@ impl container::StyleSheet for Theme {
 
     fn appearance(&self, style: &Self::Style) -> container::Appearance {
         container::Appearance {
-            background: match style {
+            background: Some(match style {
                 Self::Style::Wrapper => Color::TRANSPARENT.into(),
                 Self::Style::GameListEntry => self.field.alpha(0.15).into(),
                 Self::Style::ModalBackground | Self::Style::Notification | Self::Style::Tooltip => self.field.into(),
                 Self::Style::DisabledBackup => self.disabled.into(),
                 Self::Style::BadgeActivated => self.negative.into(),
                 _ => self.background.into(),
-            },
+            }),
             border_color: match style {
                 Self::Style::Wrapper => Color::TRANSPARENT,
                 Self::Style::GameListEntry | Self::Style::Notification => self.field,
@@ -284,9 +284,9 @@ impl container::StyleSheet for Theme {
                 | Self::Style::BadgeActivated
                 | Self::Style::BadgeFaded
                 | Self::Style::ChangeBadge(..)
-                | Self::Style::DisabledBackup => 10.0,
-                Self::Style::Notification | Self::Style::Tooltip => 20.0,
-                _ => 0.0,
+                | Self::Style::DisabledBackup => 10.0.into(),
+                Self::Style::Notification | Self::Style::Tooltip => 20.0.into(),
+                _ => 0.0.into(),
             },
             text_color: match style {
                 Self::Style::Wrapper => None,
@@ -312,13 +312,13 @@ impl scrollable::StyleSheet for Theme {
 
     fn active(&self, _style: &Self::Style) -> scrollable::Scrollbar {
         scrollable::Scrollbar {
-            background: Color::TRANSPARENT.into(),
-            border_radius: 5.0,
+            background: Some(Color::TRANSPARENT.into()),
+            border_radius: 5.0.into(),
             border_width: 0.0,
             border_color: Color::TRANSPARENT,
             scroller: scrollable::Scroller {
                 color: self.text.alpha(0.7),
-                border_radius: 5.0,
+                border_radius: 5.0.into(),
                 border_width: 0.0,
                 border_color: Color::TRANSPARENT,
             },
@@ -333,7 +333,7 @@ impl scrollable::StyleSheet for Theme {
         }
 
         scrollable::Scrollbar {
-            background: self.text.alpha(0.4).into(),
+            background: Some(self.text.alpha(0.4).into()),
             scroller: scrollable::Scroller {
                 color: self.text.alpha(0.8),
                 ..active.scroller
@@ -356,8 +356,8 @@ impl pick_list::StyleSheet for Theme {
     fn active(&self, style: &Self::Style) -> pick_list::Appearance {
         pick_list::Appearance {
             border_radius: match style {
-                Self::Style::Primary => 5.0,
-                Self::Style::Backup | Self::Style::Popup => 10.0,
+                Self::Style::Primary => 5.0.into(),
+                Self::Style::Backup | Self::Style::Popup => 10.0.into(),
             },
             background: self.field.alpha(0.6).into(),
             border_color: self.text.alpha(0.7),
@@ -385,7 +385,7 @@ impl checkbox::StyleSheet for Theme {
         checkbox::Appearance {
             background: self.field.alpha(0.6).into(),
             icon_color: self.text,
-            border_radius: 5.0,
+            border_radius: 5.0.into(),
             border_width: 1.0,
             border_color: self.text.alpha(0.6),
             text_color: Some(self.text),
@@ -408,7 +408,7 @@ impl text_input::StyleSheet for Theme {
     fn active(&self, _style: &Self::Style) -> text_input::Appearance {
         text_input::Appearance {
             background: Color::TRANSPARENT.into(),
-            border_radius: 5.0,
+            border_radius: 5.0.into(),
             border_width: 1.0,
             border_color: self.text.alpha(0.8),
             icon_color: self.negative,
@@ -455,7 +455,7 @@ impl iced::widget::progress_bar::StyleSheet for Theme {
         iced_style::progress_bar::Appearance {
             background: self.disabled.into(),
             bar: self.added.into(),
-            border_radius: 4.0,
+            border_radius: 4.0.into(),
         }
     }
 }

--- a/src/gui/widget.rs
+++ b/src/gui/widget.rs
@@ -74,12 +74,12 @@ pub fn number_input<'a>(
             .push(Text::new(label))
             .push(Text::new(value.to_string()))
             .push({
-                Button::new(Icon::Remove.as_text().width(Length::Shrink))
+                Button::new(Icon::Remove.text().width(Length::Shrink))
                     .on_press_if(|| &value > range.start(), || (change)(value - 1))
                     .style(style::Button::Negative)
             })
             .push({
-                Button::new(Icon::Add.as_text().width(Length::Shrink))
+                Button::new(Icon::Add.text().width(Length::Shrink))
                     .on_press_if(|| &value < range.end(), || (change)(value + 1))
                     .style(style::Button::Primary)
             }),

--- a/src/gui/widget.rs
+++ b/src/gui/widget.rs
@@ -30,6 +30,26 @@ pub type Undoable<'a, F> = crate::gui::undoable::Undoable<'a, Message, Renderer,
 
 pub use w::Space;
 
+pub fn checkbox<'a>(label: impl Into<String>, is_checked: bool, f: impl Fn(bool) -> Message + 'a) -> Checkbox<'a> {
+    Checkbox::new(label, is_checked, f).text_shaping(w::text::Shaping::Advanced)
+}
+
+pub fn pick_list<'a, T>(
+    options: impl Into<std::borrow::Cow<'a, [T]>>,
+    selected: Option<T>,
+    on_selected: impl Fn(T) -> Message + 'a,
+) -> PickList<'a, T>
+where
+    T: ToString + Eq + 'static,
+    [T]: ToOwned<Owned = Vec<T>>,
+{
+    PickList::new(options, selected, on_selected).text_shaping(w::text::Shaping::Advanced)
+}
+
+pub fn text<'a>(content: impl Into<std::borrow::Cow<'a, str>>) -> Text<'a> {
+    Text::new(content).shaping(w::text::Shaping::Advanced)
+}
+
 pub mod id {
     use once_cell::sync::Lazy;
 
@@ -71,8 +91,8 @@ pub fn number_input<'a>(
         Row::new()
             .spacing(5)
             .align_items(Alignment::Center)
-            .push(Text::new(label))
-            .push(Text::new(value.to_string()))
+            .push(text(label))
+            .push(text(value.to_string()))
             .push({
                 Button::new(Icon::Remove.text().width(Length::Shrink))
                     .on_press_if(|| &value > range.start(), || (change)(value - 1))
@@ -172,10 +192,10 @@ impl Progress {
                 .spacing(5)
                 .padding([0, 5, 0, 5])
                 .align_items(Alignment::Center)
-                .push_some(|| label.map(|x| Text::new(x).size(15)))
-                .push_some(|| elapsed.map(|x| Text::new(x).size(15)))
+                .push_some(|| label.map(|x| text(x).size(15)))
+                .push_some(|| elapsed.map(|x| text(x).size(15)))
                 .push(ProgressBar::new(0.0..=self.max, self.current).height(8))
-                .push_some(|| count.map(|x| Text::new(x).size(15))),
+                .push_some(|| count.map(|x| text(x).size(15))),
         )
         .height(15)
         .style(style::Container::ModalBackground)

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -98,6 +98,11 @@ impl Language {
         Self::PortugueseBrazilian,
         Self::Russian,
         Self::Ukrainian,
+        // Self::Arabic,
+        Self::ChineseSimplified,
+        Self::Japanese,
+        Self::Korean,
+        Self::Thai,
     ];
 
     pub fn id(&self) -> LanguageIdentifier {


### PR DESCRIPTION
This has some significant implications:

* Rendering now uses Vulkan/DirectX/Metal instead of OpenGL. There's also a software renderer fallback when necessary.
* Text/font handling are completely different. This also means that we can now support Chinese, Japanese, Korean, and Thai (but still not Arabic).

I've tested this on Windows and Mac, but I would appreciate some help testing on Linux and the Steam Deck. @sluedecke @LeSnake04 @TeamLinux01 @psymin, would any of you be willing to help test this?

Here's a standalone Linux build: [ludusavi-v0.20.0-post.3+da6a09e-linux.zip](https://github.com/mtkennerly/ludusavi/files/12209962/ludusavi-v0.20.0-post.3%2Bda6a09e-linux.zip), and I've also updated the beta Flatpak branch.

Flatpak beta setup:

```
flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
flatpak install flathub-beta com.github.mtkennerly.ludusavi
flatpak run com.github.mtkennerly.ludusavi//beta
```