### PR TITLE
Display file size

### DIFF
--- a/src/gui/file_tree.rs
+++ b/src/gui/file_tree.rs
@@ -146,7 +146,7 @@ impl FileTreeNode {
             return Container::new(
                 Row::new()
                     .align_items(Alignment::Center)
-                    .padding([0, 0, 0, 35 * level])
+                    .padding([0, 10, 0, 35 * level])
                     .spacing(10)
                     .push(match self.node_type {
                         FileTreeNodeType::File | FileTreeNodeType::RegistryValue(_) => {
@@ -201,6 +201,13 @@ impl FileTreeNode {
                                 text(size)
                                     .horizontal_alignment(iced::alignment::Horizontal::Right)
                                     .width(Length::Fill)
+                            })
+                            .map(|text| {
+                                if self.scanned_file.as_ref().map(|f| f.ignored).unwrap_or(false) {
+                                    text.style(style::Text::Disabled)
+                                } else {
+                                    text
+                                }
                             })
                     }),
             );

--- a/src/gui/file_tree.rs
+++ b/src/gui/file_tree.rs
@@ -191,6 +191,17 @@ impl FileTreeNode {
                                 Badge::new(&msg).view()
                             })
                         })
+                    })
+                    .push_some(|| {
+                        self.scanned_file
+                            .as_ref()
+                            .map(|f| f.size)
+                            .map(|bytes| TRANSLATOR.adjusted_size(bytes))
+                            .map(|size| {
+                                text(size)
+                                    .horizontal_alignment(iced::alignment::Horizontal::Right)
+                                    .width(150)
+                            })
                     }),
             );
         } else if self.nodes.len() == 1 {

--- a/src/gui/file_tree.rs
+++ b/src/gui/file_tree.rs
@@ -268,10 +268,10 @@ impl FileTreeNode {
                             None
                         })
                         .push_some(|| {
-                            let total_bytes = self.calculate_directory_size();
+                            let total_bytes = self.calculate_directory_size(true);
                             let total_size = total_bytes.map(|bytes| TRANSLATOR.adjusted_size(bytes));
 
-                            let included_bytes = self.calculate_included_directory_size();
+                            let included_bytes = self.calculate_directory_size(false);
                             let included_size = included_bytes.map(|bytes| TRANSLATOR.adjusted_size(bytes));
 
                             match (included_size, total_size) {
@@ -389,40 +389,17 @@ impl FileTreeNode {
         node
     }
 
-    fn calculate_directory_size(&self) -> Option<u64> {
+    fn calculate_directory_size(&self, include_ignored: bool) -> Option<u64> {
         let mut size = 0;
         for child_node in self.nodes.values() {
             if child_node.nodes.is_empty() {
                 if let Some(scanned_file) = &child_node.scanned_file {
-                    size += scanned_file.size;
-                }
-            } else {
-                let child_size = child_node.calculate_directory_size().unwrap_or(0);
-                size += child_size;
-            }
-        }
-
-        if size == 0 {
-            None
-        } else {
-            Some(size)
-        }
-    }
-
-    fn calculate_included_directory_size(&self) -> Option<u64> {
-        if self.ignored {
-            return None;
-        }
-        let mut size = 0;
-        for child_node in self.nodes.values() {
-            if child_node.nodes.is_empty() {
-                if let Some(scanned_file) = &child_node.scanned_file {
-                    if !scanned_file.ignored {
+                    if include_ignored || !scanned_file.ignored {
                         size += scanned_file.size;
                     }
                 }
             } else {
-                let child_size = child_node.calculate_included_directory_size().unwrap_or(0);
+                let child_size = child_node.calculate_directory_size(include_ignored).unwrap_or(0);
                 size += child_size;
             }
         }

--- a/src/gui/file_tree.rs
+++ b/src/gui/file_tree.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
-use iced::Alignment;
+use iced::{Alignment, Length};
 
 use crate::{
     gui::{
@@ -200,7 +200,7 @@ impl FileTreeNode {
                             .map(|size| {
                                 text(size)
                                     .horizontal_alignment(iced::alignment::Horizontal::Right)
-                                    .width(150)
+                                    .width(Length::Fill)
                             })
                     }),
             );

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -96,6 +96,7 @@ pub enum Text {
     #[default]
     Default,
     Failure,
+    Disabled,
 }
 impl iced::widget::text::StyleSheet for Theme {
     type Style = Text;
@@ -105,6 +106,9 @@ impl iced::widget::text::StyleSheet for Theme {
             Text::Default => iced::widget::text::Appearance { color: None },
             Text::Failure => iced::widget::text::Appearance {
                 color: Some(self.negative),
+            },
+            Text::Disabled => iced::widget::text::Appearance {
+                color: Some(self.disabled),
             },
         }
     }


### PR DESCRIPTION
Displays the size of a file or directory on the file tree.

Files and complete directories display file size, partially selected directories display selected / total, and unselected files and directories show the total size in grey.