### PR TITLE
Refactor `StrictPath` internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,26 @@
   * GUI: After performing a cloud upload preview on the other screen,
     the very next backup preview wouldn't do anything.
   * CLI: The `wrap` command did not fail gracefully when the game launch commands were missing.
+  * If a game had more data that failed to back up than succeeded,
+    then the backup size would be reported incorrectly.
 * Changed:
+  * The way Ludusavi parses file paths internally has been overhauled.
+    The majority of the observable behavior is the same,
+    but it is now more predictable and correct when parsing Linux-style paths on Windows and vice versa.
+
+    Some behavioral changes worth noting:
+
+    * You can now configure redirects that change Windows/Linux-style paths into the other format.
+      For example, if you configure a backup redirect from `C:\games` to `/opt/games`,
+      then the backup will contain references to `/opt/games`.
+      (Previously, `/opt/games` would turn into `C:/opt/games` when parsed on Windows,
+      and `C:\games` would turn into `./C_/games` when parsed on Linux.)
+    * On Windows, you can no longer write `/games` as an alias of `C:\games`.
+      These are now treated as distinct paths.
+      (Previously, on Windows, Linux-style paths were interpreted as `C:` paths.)
+    * If you try to restore Windows-style paths on Linux or vice versa,
+      it will now produce an error,
+      unless you've configured an applicable redirect.
   * On Windows, the way Ludusavi hides its console in GUI mode has changed,
     in order to avoid a new false positive from Windows Defender.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,7 @@ dependencies = [
  "signal-hook",
  "steamlocate",
  "tokio",
+ "typed-path",
  "unic-langid",
  "velcro",
  "walkdir",
@@ -4170,6 +4171,12 @@ checksum = "b6d3364c5e96cb2ad1603037ab253ddd34d7fb72a58bdddf4b7350760fc69a46"
 dependencies = [
  "rustc-hash",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6069e2cc1d241fd4ff5fa067e8882996fcfce20986d078696e05abccbcf27b43"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ shlex = "1.3.0"
 signal-hook = "0.3.17"
 steamlocate = "2.0.0-beta.2"
 tokio = { version = "1.36.0", features = ["macros", "time"] }
+typed-path = "0.8.0"
 unic-langid = "0.9.4"
 walkdir = "2.5.0"
 which = "6.0.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -287,7 +287,7 @@ pub fn run(sub: Subcommand, no_manifest_update: bool, try_manifest_update: bool)
                         game,
                         name,
                         &roots,
-                        &StrictPath::from(app_dir()),
+                        &app_dir(),
                         &launchers,
                         &filter,
                         &wine_prefix,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -287,7 +287,7 @@ pub fn run(sub: Subcommand, no_manifest_update: bool, try_manifest_update: bool)
                         game,
                         name,
                         &roots,
-                        &StrictPath::from_std_path_buf(&app_dir()),
+                        &StrictPath::from(app_dir()),
                         &launchers,
                         &filter,
                         &wine_prefix,

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -20,8 +20,9 @@ fn parse_strict_path(path: &str) -> Result<StrictPath, std::io::Error> {
 }
 
 fn parse_existing_strict_path(path: &str) -> Result<StrictPath, std::io::Error> {
-    let sp = StrictPath::new(path.to_owned());
-    std::fs::canonicalize(sp.interpret())?;
+    let cwd = StrictPath::cwd();
+    let sp = StrictPath::relative(path.to_owned(), Some(cwd.raw()));
+    sp.metadata()?;
     Ok(sp)
 }
 
@@ -912,7 +913,10 @@ mod tests {
                 try_manifest_update: false,
                 sub: Some(Subcommand::Restore {
                     preview: true,
-                    path: Some(StrictPath::new(s("tests/backup"))),
+                    path: Some(StrictPath::relative(
+                        s("tests/backup"),
+                        Some(StrictPath::cwd().interpret()),
+                    )),
                     force: true,
                     api: true,
                     sort: Some(CliSort::Name),

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -915,7 +915,7 @@ mod tests {
                     preview: true,
                     path: Some(StrictPath::relative(
                         s("tests/backup"),
-                        Some(StrictPath::cwd().interpret()),
+                        Some(StrictPath::cwd().interpret().unwrap()),
                     )),
                     force: true,
                     api: true,

--- a/src/cli/report.rs
+++ b/src/cli/report.rs
@@ -547,14 +547,6 @@ mod tests {
         testing::s,
     };
 
-    fn drive() -> String {
-        if cfg!(target_os = "windows") {
-            StrictPath::new(s("foo")).render()[..2].to_string()
-        } else {
-            s("")
-        }
-    }
-
     #[test]
     fn can_render_in_standard_mode_with_minimal_input() {
         let mut reporter = Reporter::standard();
@@ -566,15 +558,12 @@ mod tests {
             &DuplicateDetector::default(),
         );
         assert_eq!(
-            format!(
-                r#"
+            r#"
 Overall:
   Games: 0
   Size: 0 B
-  Location: {}/dev/null
-            "#,
-                &drive()
-            )
+  Location: /dev/null
+            "#
             .trim_end(),
             reporter.render(&StrictPath::new(s("/dev/null")))
         )
@@ -631,8 +620,8 @@ Overall:
         assert_eq!(
             r#"
 foo [100.00 KiB]:
-  - <drive>/file1
-  - [FAILED] <drive>/file2
+  - /file1
+  - [FAILED] /file2
   - [FAILED] HKEY_CURRENT_USER/Key1
   - HKEY_CURRENT_USER/Key2
   - HKEY_CURRENT_USER/Key3
@@ -641,10 +630,9 @@ foo [100.00 KiB]:
 Overall:
   Games: 1
   Size: 100.00 KiB / 150.00 KiB
-  Location: <drive>/dev/null
+  Location: /dev/null
             "#
-            .trim()
-            .replace("<drive>", &drive()),
+            .trim(),
             reporter.render(&StrictPath::new(s("/dev/null")))
         );
     }
@@ -708,18 +696,17 @@ Overall:
         assert_eq!(
             r#"
 foo [1 B]:
-  - <drive>/file1
+  - /file1
 
 bar [3 B]:
-  - <drive>/file2
+  - /file2
 
 Overall:
   Games: 2
   Size: 4 B
-  Location: <drive>/dev/null
+  Location: /dev/null
             "#
-            .trim()
-            .replace("<drive>", &drive()),
+            .trim(),
             reporter.render(&StrictPath::new(s("/dev/null")))
         );
     }
@@ -734,20 +721,20 @@ Overall:
                 game_name: s("foo"),
                 found_files: hash_set! {
                     ScannedFile {
-                        path: StrictPath::new(format!("{}/backup/file1", drive())),
+                        path: StrictPath::new(s("/backup/file1")),
                         size: 102_400,
                         hash: "1".to_string(),
-                        original_path: Some(StrictPath::new(format!("{}/original/file1", drive()))),
+                        original_path: Some(StrictPath::new(s("/original/file1"))),
                         ignored: false,
                         change: Default::default(),
                         container: None,
                         redirected: None,
                     },
                     ScannedFile {
-                        path: StrictPath::new(format!("{}/backup/file2", drive())),
+                        path: StrictPath::new(s("/backup/file2")),
                         size: 51_200,
                         hash: "2".to_string(),
-                        original_path: Some(StrictPath::new(format!("{}/original/file2", drive()))),
+                        original_path: Some(StrictPath::new(s("/original/file2"))),
                         ignored: false,
                         change: Default::default(),
                         container: None,
@@ -764,16 +751,15 @@ Overall:
         assert_eq!(
             r#"
 foo [150.00 KiB]:
-  - <drive>/original/file1
-  - <drive>/original/file2
+  - /original/file1
+  - /original/file2
 
 Overall:
   Games: 1
   Size: 150.00 KiB
-  Location: <drive>/dev/null
+  Location: /dev/null
             "#
-            .trim()
-            .replace("<drive>", &drive()),
+            .trim(),
             reporter.render(&StrictPath::new(s("/dev/null")))
         );
     }
@@ -818,16 +804,15 @@ Overall:
         assert_eq!(
             r#"
 foo [100.00 KiB] [DUPLICATES]:
-  - [DUPLICATED] <drive>/file1
+  - [DUPLICATED] /file1
   - [DUPLICATED] HKEY_CURRENT_USER/Key1
 
 Overall:
   Games: 1
   Size: 100.00 KiB
-  Location: <drive>/dev/null
+  Location: /dev/null
             "#
-            .trim()
-            .replace("<drive>", &drive()),
+            .trim(),
             reporter.render(&StrictPath::new(s("/dev/null")))
         );
     }
@@ -876,21 +861,20 @@ Overall:
         assert_eq!(
             r#"
 foo [4 B] [Δ]:
-  - [Δ] <drive>/different
-  - [+] <drive>/new
-  - <drive>/same
-  - <drive>/unknown
+  - [Δ] /different
+  - [+] /new
+  - /same
+  - /unknown
 
 bar [1 B] [+]:
-  - [+] <drive>/brand-new
+  - [+] /brand-new
 
 Overall:
   Games: 2 [+1] [Δ1]
   Size: 5 B
-  Location: <drive>/dev/null
+  Location: /dev/null
             "#
-            .trim()
-            .replace("<drive>", &drive()),
+            .trim(),
             reporter.render(&StrictPath::new(s("/dev/null")))
         );
     }
@@ -980,11 +964,11 @@ Overall:
       "decision": "Processed",
       "change": "Same",
       "files": {
-        "<drive>/file1": {
+        "/file1": {
           "change": "Unknown",
           "bytes": 100
         },
-        "<drive>/file2": {
+        "/file2": {
           "failed": true,
           "change": "Unknown",
           "bytes": 50
@@ -1011,8 +995,7 @@ Overall:
   }
 }
             "#
-            .trim()
-            .replace("<drive>", &drive()),
+            .trim(),
             reporter.render(&StrictPath::new(s("/dev/null")))
         );
     }
@@ -1027,20 +1010,20 @@ Overall:
                 game_name: s("foo"),
                 found_files: hash_set! {
                     ScannedFile {
-                        path: StrictPath::new(format!("{}/backup/file1", drive())),
+                        path: StrictPath::new(s("/backup/file1")),
                         size: 100,
                         hash: "1".to_string(),
-                        original_path: Some(StrictPath::new(format!("{}/original/file1", drive()))),
+                        original_path: Some(StrictPath::new(s("/original/file1"))),
                         ignored: false,
                         change: Default::default(),
                         container: None,
                         redirected: None,
                     },
                     ScannedFile {
-                        path: StrictPath::new(format!("{}/backup/file2", drive())),
+                        path: StrictPath::new(s("/backup/file2")),
                         size: 50,
                         hash: "2".to_string(),
-                        original_path: Some(StrictPath::new(format!("{}/original/file2", drive()))),
+                        original_path: Some(StrictPath::new(s("/original/file2"))),
                         ignored: false,
                         change: Default::default(),
                         container: None,
@@ -1073,11 +1056,11 @@ Overall:
       "decision": "Processed",
       "change": "Same",
       "files": {
-        "<drive>/original/file1": {
+        "/original/file1": {
           "change": "Unknown",
           "bytes": 100
         },
-        "<drive>/original/file2": {
+        "/original/file2": {
           "change": "Unknown",
           "bytes": 50
         }
@@ -1087,8 +1070,7 @@ Overall:
   }
 }
             "#
-            .trim()
-            .replace("<drive>", &drive()),
+            .trim(),
             reporter.render(&StrictPath::new(s("/dev/null")))
         );
     }
@@ -1149,7 +1131,7 @@ Overall:
       "decision": "Processed",
       "change": "Same",
       "files": {
-        "<drive>/file1": {
+        "/file1": {
           "change": "Unknown",
           "bytes": 100,
           "duplicatedBy": [
@@ -1169,8 +1151,7 @@ Overall:
   }
 }
             "#
-            .trim()
-            .replace("<drive>", &drive()),
+            .trim(),
             reporter.render(&StrictPath::new(s("/dev/null")))
         );
     }
@@ -1218,19 +1199,19 @@ Overall:
       "decision": "Processed",
       "change": "Different",
       "files": {
-        "<drive>/different": {
+        "/different": {
           "change": "Different",
           "bytes": 1
         },
-        "<drive>/new": {
+        "/new": {
           "change": "New",
           "bytes": 1
         },
-        "<drive>/same": {
+        "/same": {
           "change": "Same",
           "bytes": 1
         },
-        "<drive>/unknown": {
+        "/unknown": {
           "change": "Unknown",
           "bytes": 1
         }
@@ -1240,8 +1221,7 @@ Overall:
   }
 }
             "#
-            .trim()
-            .replace("<drive>", &drive()),
+            .trim(),
             reporter.render(&StrictPath::new(s("/dev/null")))
         );
     }

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -402,7 +402,7 @@ impl App {
                                 &game,
                                 &key,
                                 &roots,
-                                &StrictPath::from(app_dir()),
+                                &app_dir(),
                                 &launchers,
                                 &filter,
                                 &None,

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -402,7 +402,7 @@ impl App {
                                 &game,
                                 &key,
                                 &roots,
-                                &StrictPath::from_std_path_buf(&app_dir()),
+                                &StrictPath::from(app_dir()),
                                 &launchers,
                                 &filter,
                                 &None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use crate::{
 fn prepare_logging() -> Result<flexi_logger::LoggerHandle, flexi_logger::FlexiLoggerError> {
     flexi_logger::Logger::try_with_env_or_str("ludusavi=warn")
         .unwrap()
-        .log_to_file(flexi_logger::FileSpec::default().directory(app_dir()))
+        .log_to_file(flexi_logger::FileSpec::default().directory(app_dir().as_std_path_buf().unwrap()))
         .write_mode(flexi_logger::WriteMode::Async)
         .rotate(
             flexi_logger::Criterion::Size(1024 * 1024 * 10),

--- a/src/path.rs
+++ b/src/path.rs
@@ -317,8 +317,9 @@ impl StrictPath {
         }
     }
 
+    // TODO: Better error reporting for incompatible UNC path variants.
     pub fn globbable(&self) -> String {
-        self.display().trim().trim_matches(['/', '\\']).replace('\\', "/")
+        self.display().trim().trim_end_matches(['/', '\\']).replace('\\', "/")
     }
 
     fn canonical(&self) -> Canonical {

--- a/src/path.rs
+++ b/src/path.rs
@@ -362,6 +362,15 @@ impl StrictPath {
         }
     }
 
+    /// This is for a special case when we're scanning a dummy root.
+    pub fn interpret_unless_skip(&self) -> Result<String, StrictPathError> {
+        if self.raw == SKIP {
+            Ok(SKIP.to_string())
+        } else {
+            self.interpret()
+        }
+    }
+
     pub fn interpreted(&self) -> Result<Self, StrictPathError> {
         Ok(Self {
             raw: self.interpret()?,

--- a/src/path.rs
+++ b/src/path.rs
@@ -855,33 +855,13 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_os = "windows")]
         fn can_split_drive_for_windows_path() {
             assert_eq!((s("C:"), s("foo/bar")), StrictPath::new(s("C:/foo/bar")).split_drive());
         }
 
         #[test]
-        #[cfg(not(target_os = "windows"))]
         fn can_split_drive_for_nonwindows_path() {
             assert_eq!((s(""), s("foo/bar")), StrictPath::new(s("/foo/bar")).split_drive());
-        }
-
-        #[test]
-        #[cfg(target_os = "windows")]
-        fn can_split_drive_for_linux_path_in_windows() {
-            assert_eq!(
-                (s(""), s("Users/foo/AppData")),
-                StrictPath::new(s("/Users/foo/AppData")).split_drive()
-            );
-        }
-
-        #[test]
-        #[cfg(not(target_os = "windows"))]
-        fn can_split_drive_for_windows_path_in_linux() {
-            assert_eq!(
-                (s("C"), s("Users/foo/AppData")),
-                StrictPath::new(s("C:/Users/foo/AppData")).split_drive()
-            );
         }
 
         #[test]
@@ -895,7 +875,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_os = "windows")]
         fn is_prefix_of_with_windows_drive_letters() {
             assert!(StrictPath::new(s(r#"C:"#)).is_prefix_of(&StrictPath::new(s("C:/foo"))));
             assert!(StrictPath::new(s(r#"C:/"#)).is_prefix_of(&StrictPath::new(s("C:/foo"))));
@@ -903,7 +882,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_os = "windows")]
         fn is_prefix_of_with_unc_drives() {
             assert!(!StrictPath::new(s(r#"\\?\C:\foo"#)).is_prefix_of(&StrictPath::new(s("C:/foo"))));
             assert!(StrictPath::new(s(r#"\\?\C:\foo"#)).is_prefix_of(&StrictPath::new(s("C:/foo/bar"))));
@@ -1189,6 +1167,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg(target_os = "windows")]
         fn does_not_truncate_path_up_to_drive_letter_in_windows_classic_path() {
             // https://github.com/mtkennerly/ludusavi/issues/36
             // Test for: <winDocuments>/<home>
@@ -1202,6 +1181,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg(target_os = "windows")]
         fn does_not_truncate_path_up_to_drive_letter_in_windows_unc_path() {
             // https://github.com/mtkennerly/ludusavi/issues/36
             // Test for: <winDocuments>/<home>

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -145,9 +145,9 @@ impl CommandError {
     }
 }
 
-pub fn app_dir() -> std::path::PathBuf {
+pub fn app_dir() -> StrictPath {
     if let Some(dir) = CONFIG_DIR.lock().unwrap().as_ref() {
-        return dir.clone();
+        return StrictPath::from(dir.clone());
     }
 
     if let Ok(mut flag) = std::env::current_exe() {
@@ -155,11 +155,11 @@ pub fn app_dir() -> std::path::PathBuf {
         flag.push(PORTABLE_FLAG_FILE_NAME);
         if flag.exists() {
             flag.pop();
-            return flag;
+            return StrictPath::from(flag);
         }
     }
 
-    StrictPath::new(format!("{}/{}", CommonPath::Config.get().unwrap(), APP_DIR_NAME)).as_std_path_buf()
+    StrictPath::new(format!("{}/{}", CommonPath::Config.get().unwrap(), APP_DIR_NAME))
 }
 
 pub fn filter_map_walkdir(e: Result<walkdir::DirEntry, walkdir::Error>) -> Option<walkdir::DirEntry> {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -2,7 +2,7 @@ pub mod cache;
 pub mod config;
 pub mod manifest;
 
-use crate::prelude::{app_dir, AnyError};
+use crate::prelude::{app_dir, AnyError, StrictPath};
 
 pub trait ResourceFile
 where
@@ -10,10 +10,8 @@ where
 {
     const FILE_NAME: &'static str;
 
-    fn path() -> std::path::PathBuf {
-        let mut path = app_dir();
-        path.push(Self::FILE_NAME);
-        path
+    fn path() -> StrictPath {
+        app_dir().joined(Self::FILE_NAME)
     }
 
     /// If the resource file does not exist, use default data and apply these modifications.
@@ -30,7 +28,7 @@ where
         Self::load_from(&Self::path())
     }
 
-    fn load_from(path: &std::path::PathBuf) -> Result<Self, AnyError> {
+    fn load_from(path: &StrictPath) -> Result<Self, AnyError> {
         if !path.exists() {
             return Ok(Self::default().initialize());
         }
@@ -38,13 +36,13 @@ where
         Self::load_from_string(&content)
     }
 
-    fn load_from_existing(path: &std::path::PathBuf) -> Result<Self, AnyError> {
+    fn load_from_existing(path: &StrictPath) -> Result<Self, AnyError> {
         let content = Self::load_raw(path)?;
         Self::load_from_string(&content)
     }
 
-    fn load_raw(path: &std::path::PathBuf) -> Result<String, AnyError> {
-        Ok(std::fs::read_to_string(path)?)
+    fn load_raw(path: &StrictPath) -> Result<String, AnyError> {
+        path.try_read()
     }
 
     fn load_from_string(content: &str) -> Result<Self, AnyError> {
@@ -65,8 +63,8 @@ where
             }
         }
 
-        if std::fs::create_dir_all(app_dir()).is_ok() {
-            let _ = std::fs::write(Self::path(), new_content.as_bytes());
+        if Self::path().create_parent_dir().is_ok() {
+            let _ = Self::path().write_with_content(&new_content);
         }
     }
 }

--- a/src/resource/cache.rs
+++ b/src/resource/cache.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashMap};
 
 use crate::{
     lang::Language,
-    prelude::{app_dir, StrictPath, CANONICAL_VERSION},
+    prelude::{app_dir, CANONICAL_VERSION},
     resource::{
         config::{Config, RootsConfig},
         manifest::ManifestUpdate,
@@ -69,9 +69,7 @@ impl Cache {
         let mut updated = false;
 
         if !self.migrations.adopted_cache {
-            let _ = StrictPath::from(app_dir())
-                .joined(".flag_migrated_legacy_config")
-                .remove();
+            let _ = app_dir().joined(".flag_migrated_legacy_config").remove();
             self.migrations.adopted_cache = true;
             updated = true;
         }
@@ -114,10 +112,7 @@ impl Cache {
     pub fn add_roots(&mut self, roots: &Vec<RootsConfig>) {
         for root in roots {
             if !self.has_root(root) {
-                self.roots.insert(RootsConfig {
-                    path: root.path.interpreted(),
-                    store: root.store,
-                });
+                self.roots.insert(root.clone());
             }
         }
     }
@@ -125,6 +120,6 @@ impl Cache {
     pub fn has_root(&self, root: &RootsConfig) -> bool {
         self.roots
             .iter()
-            .any(|x| x.path.interpret() == root.path.interpret() && x.store == root.store)
+            .any(|x| x.path.equivalent(&root.path) && x.store == root.store)
     }
 }

--- a/src/resource/config.rs
+++ b/src/resource/config.rs
@@ -75,17 +75,17 @@ impl ManifestConfig {
             .iter()
             .filter_map(|x| match x {
                 SecondaryManifestConfig::Local { path } => {
-                    let manifest = Manifest::load_from_existing(&path.as_std_path_buf());
+                    let manifest = Manifest::load_from_existing(path);
                     if let Err(e) = &manifest {
-                        log::error!("Cannot load secondary manifest: {} | {}", path.render(), e);
+                        log::error!("Cannot load secondary manifest: {:?} | {}", &path, e);
                     }
                     Some((path.clone(), manifest.ok()?))
                 }
                 SecondaryManifestConfig::Remote { url } => {
                     let path = Manifest::path_for(url, false);
-                    let manifest = Manifest::load_from(&path.as_std_path_buf());
+                    let manifest = Manifest::load_from(&path);
                     if let Err(e) = &manifest {
-                        log::error!("Cannot load manifest: {} | {}", path.render(), e);
+                        log::error!("Cannot load manifest: {:?} | {}", &path, e);
                     }
                     Some((path.clone(), manifest.ok()?))
                 }
@@ -224,7 +224,7 @@ impl RootsConfig {
             })
             .glob()
             .into_iter()
-            .filter_map(|path| match Manifest::load_from(&path.as_std_path_buf()) {
+            .filter_map(|path| match Manifest::load_from(&path) {
                 Ok(manifest) => {
                     log::info!("Loaded secondary manifest: {}", path.render());
                     log::trace!("Secondary manifest content: {:?}", &manifest);
@@ -956,10 +956,8 @@ impl ResourceFile for Config {
 impl SaveableResourceFile for Config {}
 
 impl Config {
-    fn file_archived_invalid() -> std::path::PathBuf {
-        let mut path = app_dir();
-        path.push("config.invalid.yaml");
-        path
+    fn file_archived_invalid() -> StrictPath {
+        app_dir().joined("config.invalid.yaml")
     }
 
     pub fn load() -> Result<Self, Error> {
@@ -967,7 +965,7 @@ impl Config {
     }
 
     pub fn archive_invalid() -> Result<(), Box<dyn std::error::Error>> {
-        std::fs::rename(Self::path(), Self::file_archived_invalid())?;
+        Self::path().move_to(&Self::file_archived_invalid())?;
         Ok(())
     }
 
@@ -1084,10 +1082,10 @@ impl Config {
         let mut checked = HashSet::<StrictPath>::new();
         let mut roots = vec![];
         for (path, store) in [candidates, detected_steam, detected_epic].concat() {
-            let sp = StrictPath::new(path);
-            if self.roots.iter().any(|root| root.path.interpret() == sp.interpret())
-                || checked.contains(&sp.interpreted())
-            {
+            let Ok(sp) = StrictPath::new(path).interpreted() else {
+                continue;
+            };
+            if self.roots.iter().any(|root| root.path.equivalent(&sp)) || checked.contains(&sp) {
                 continue;
             }
             if sp.is_dir() {
@@ -1096,7 +1094,7 @@ impl Config {
                     store,
                 });
             }
-            checked.insert(sp.interpreted());
+            checked.insert(sp);
         }
 
         roots
@@ -1220,7 +1218,7 @@ impl Config {
     pub fn expanded_roots(&self) -> Vec<RootsConfig> {
         for root in &self.roots {
             log::trace!(
-                "Configured root ({:?}): {} | interpreted: {} | exists: {} | is dir: {}",
+                "Configured root ({:?}): {} | interpreted: {:?} | exists: {} | is dir: {}",
                 &root.store,
                 &root.path.raw(),
                 &root.path.interpret(),
@@ -1233,7 +1231,7 @@ impl Config {
 
         for root in &expanded {
             log::trace!(
-                "Expanded root ({:?}): {} | interpreted: {} | exists: {} | is dir: {}",
+                "Expanded root ({:?}): {} | interpreted: {:?} | exists: {} | is dir: {}",
                 &root.store,
                 &root.path.raw(),
                 &root.path.interpret(),

--- a/src/resource/config.rs
+++ b/src/resource/config.rs
@@ -300,12 +300,11 @@ impl BackupFilter {
 
         let mut builder = globset::GlobSetBuilder::new();
         for item in &self.ignored_paths {
-            let normalized = crate::path::parse_home(&item.raw()).replace('\\', "/");
-            let normalized = normalized.trim_end_matches('/');
+            let normalized = item.globbable();
 
             let variants = vec![
                 normalized.to_string(),
-                // If the user has specified a plain folder, we also want to ignore its children.
+                // If the user has specified a plain folder, we also want to include its children.
                 format!("{}/**", &normalized),
             ];
 

--- a/src/resource/config.rs
+++ b/src/resource/config.rs
@@ -268,7 +268,7 @@ impl ToString for RedirectKind {
     }
 }
 
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct BackupFilter {
     #[serde(default, rename = "excludeStoreScreenshots")]
     pub exclude_store_screenshots: bool,
@@ -278,6 +278,16 @@ pub struct BackupFilter {
     pub ignored_registry: Vec<RegistryItem>,
     #[serde(skip)]
     pub path_globs: Arc<Mutex<Option<globset::GlobSet>>>,
+}
+
+impl std::fmt::Debug for BackupFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BackupFilter")
+            .field("exclude_store_screenshots", &self.exclude_store_screenshots)
+            .field("ignored_paths", &self.ignored_paths)
+            .field("ignored_registry", &self.ignored_registry)
+            .finish()
+    }
 }
 
 impl Eq for BackupFilter {}

--- a/src/resource/manifest.rs
+++ b/src/resource/manifest.rs
@@ -282,11 +282,9 @@ impl Manifest {
 
     pub fn path_for(url: &str, primary: bool) -> StrictPath {
         if primary {
-            Self::path().into()
+            Self::path()
         } else {
-            let mut path = app_dir();
-            path.push(Self::file_name_for(url, primary));
-            path.into()
+            app_dir().joined(&Self::file_name_for(url, primary))
         }
     }
 
@@ -358,7 +356,7 @@ impl Manifest {
         let mut res = req.send().map_err(|_e| cannot_update())?;
         match res.status() {
             reqwest::StatusCode::OK => {
-                std::fs::create_dir_all(app_dir()).map_err(|_| cannot_update())?;
+                app_dir().create_dirs().map_err(|_| cannot_update())?;
 
                 // Ensure that the manifest data is valid before we save it.
                 let mut manifest_bytes = vec![];
@@ -371,7 +369,7 @@ impl Manifest {
                     });
                 }
 
-                std::fs::write(path.as_std_path_buf(), manifest_string).map_err(|_| cannot_update())?;
+                path.write_with_content(&manifest_string).map_err(|_| cannot_update())?;
 
                 let new_etag = res
                     .headers()

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1174,69 +1174,115 @@ mod tests {
     }
 
     #[test]
-    fn can_scan_game_for_backup_with_file_matches_and_ignores() {
-        let cases = [
-            (
-                BackupFilter {
-                    ignored_paths: vec![StrictPath::new(format!("{}\\tests/root1/game1/subdir", repo()))],
-                    ..Default::default()
-                },
-                ToggledPaths::default(),
-                hash_set! {
-                    ScannedFile::new(format!("{}/tests/root2/game1/file1.txt", repo()), 1, "3a52ce780950d4d969792a2559cd519d7ee8c727").change_new(),
-                },
-            ),
-            (
-                BackupFilter::default(),
-                ToggledPaths::new(btree_map! {
-                    s("game1"): btree_map! {
-                        StrictPath::new(format!("{}\\tests/root1/game1/subdir", repo())): false
-                    }
-                }),
-                hash_set! {
-                    ScannedFile::new(format!("{}/tests/root1/game1/subdir/file2.txt", repo()), 2, "9d891e731f75deae56884d79e9816736b7488080").change_new().ignored(),
-                    ScannedFile::new(format!("{}/tests/root2/game1/file1.txt", repo()), 1, "3a52ce780950d4d969792a2559cd519d7ee8c727").change_new(),
-                },
-            ),
-            (
-                BackupFilter::default(),
-                ToggledPaths::new(btree_map! {
-                    s("game1"): btree_map! {
-                        StrictPath::new(format!("{}\\tests/root1/game1/subdir/file2.txt", repo())): false
-                    }
-                }),
-                hash_set! {
-                    ScannedFile::new(format!("{}/tests/root1/game1/subdir/file2.txt", repo()), 2, "9d891e731f75deae56884d79e9816736b7488080").change_new().ignored(),
-                    ScannedFile::new(format!("{}/tests/root2/game1/file1.txt", repo()), 1, "3a52ce780950d4d969792a2559cd519d7ee8c727").change_new(),
-                },
-            ),
-        ];
+    fn can_scan_game_for_backup_with_file_matches_and_ignored_directory() {
+        let mut filter = BackupFilter {
+            ignored_paths: vec![StrictPath::new(format!("{}\\tests/root1/game1/subdir", repo()))],
+            ..Default::default()
+        };
+        let ignored = ToggledPaths::default();
+        let found = hash_set! {
+            ScannedFile::new(format!("{}/tests/root2/game1/file1.txt", repo()), 1, "3a52ce780950d4d969792a2559cd519d7ee8c727").change_new(),
+        };
 
-        for (mut filter, ignored, found) in cases {
-            filter.build_globs();
-            assert_eq!(
-                ScanInfo {
-                    game_name: s("game1"),
-                    found_files: found,
-                    found_registry_keys: hash_set! {},
-                    ..Default::default()
-                },
-                scan_game_for_backup(
-                    &manifest().0["game1"],
-                    "game1",
-                    &config().roots,
-                    &StrictPath::new(repo()),
-                    &Launchers::scan_dirs(&config().roots, &manifest(), &["game1".to_string()]),
-                    &filter,
-                    &None,
-                    &ignored,
-                    &ToggledRegistry::default(),
-                    None,
-                    &[],
-                    &Default::default(),
-                ),
-            );
-        }
+        filter.build_globs();
+        assert_eq!(
+            ScanInfo {
+                game_name: s("game1"),
+                found_files: found,
+                found_registry_keys: hash_set! {},
+                ..Default::default()
+            },
+            scan_game_for_backup(
+                &manifest().0["game1"],
+                "game1",
+                &config().roots,
+                &StrictPath::new(repo()),
+                &Launchers::scan_dirs(&config().roots, &manifest(), &["game1".to_string()]),
+                &filter,
+                &None,
+                &ignored,
+                &ToggledRegistry::default(),
+                None,
+                &[],
+                &Default::default(),
+            ),
+        );
+    }
+
+    #[test]
+    fn can_scan_game_for_backup_with_file_matches_and_toggled_directory() {
+        let mut filter = BackupFilter::default();
+        let ignored = ToggledPaths::new(btree_map! {
+            s("game1"): btree_map! {
+                StrictPath::new(format!("{}\\tests/root1/game1/subdir", repo())): false
+            }
+        });
+        let found = hash_set! {
+            ScannedFile::new(format!("{}/tests/root1/game1/subdir/file2.txt", repo()), 2, "9d891e731f75deae56884d79e9816736b7488080").change_new().ignored(),
+            ScannedFile::new(format!("{}/tests/root2/game1/file1.txt", repo()), 1, "3a52ce780950d4d969792a2559cd519d7ee8c727").change_new(),
+        };
+
+        filter.build_globs();
+        assert_eq!(
+            ScanInfo {
+                game_name: s("game1"),
+                found_files: found,
+                found_registry_keys: hash_set! {},
+                ..Default::default()
+            },
+            scan_game_for_backup(
+                &manifest().0["game1"],
+                "game1",
+                &config().roots,
+                &StrictPath::new(repo()),
+                &Launchers::scan_dirs(&config().roots, &manifest(), &["game1".to_string()]),
+                &filter,
+                &None,
+                &ignored,
+                &ToggledRegistry::default(),
+                None,
+                &[],
+                &Default::default(),
+            ),
+        );
+    }
+
+    #[test]
+    fn can_scan_game_for_backup_with_file_matches_and_toggled_file() {
+        let mut filter = BackupFilter::default();
+        let ignored = ToggledPaths::new(btree_map! {
+            s("game1"): btree_map! {
+                StrictPath::new(format!("{}\\tests/root1/game1/subdir/file2.txt", repo())): false
+            }
+        });
+        let found = hash_set! {
+            ScannedFile::new(format!("{}/tests/root1/game1/subdir/file2.txt", repo()), 2, "9d891e731f75deae56884d79e9816736b7488080").change_new().ignored(),
+            ScannedFile::new(format!("{}/tests/root2/game1/file1.txt", repo()), 1, "3a52ce780950d4d969792a2559cd519d7ee8c727").change_new(),
+        };
+
+        filter.build_globs();
+        assert_eq!(
+            ScanInfo {
+                game_name: s("game1"),
+                found_files: found,
+                found_registry_keys: hash_set! {},
+                ..Default::default()
+            },
+            scan_game_for_backup(
+                &manifest().0["game1"],
+                "game1",
+                &config().roots,
+                &StrictPath::new(repo()),
+                &Launchers::scan_dirs(&config().roots, &manifest(), &["game1".to_string()]),
+                &filter,
+                &None,
+                &ignored,
+                &ToggledRegistry::default(),
+                None,
+                &[],
+                &Default::default(),
+            ),
+        );
     }
 
     #[test]

--- a/src/scan/launchers/generic.rs
+++ b/src/scan/launchers/generic.rs
@@ -61,7 +61,8 @@ pub fn scan(root: &RootsConfig, manifest: &Manifest, subjects: &[String]) -> Has
     };
     let matcher = make_fuzzy_matcher();
 
-    let actual_dirs: Vec<_> = std::fs::read_dir(install_parent.interpret())
+    let actual_dirs: Vec<_> = install_parent
+        .read_dir()
         .map(|entries| {
             entries
                 .filter_map(|entry| entry.ok())

--- a/src/scan/launchers/heroic.rs
+++ b/src/scan/launchers/heroic.rs
@@ -76,8 +76,8 @@ pub fn get_legendary_installed_games(root: &RootsConfig, legendary: Option<&Stri
 
     let legendary_paths = match legendary {
         None => vec![
-            StrictPath::relative("../legendary".to_string(), Some(root.path.interpret())),
-            StrictPath::relative("legendaryConfig/legendary".to_string(), Some(root.path.interpret())),
+            root.path.popped().joined("legendary"),
+            root.path.joined("legendaryConfig/legendary"),
             StrictPath::new("~/.config/legendary".to_string()),
         ],
         Some(x) => vec![x.clone()],
@@ -120,10 +120,7 @@ fn detect_legendary_games(
 }
 
 pub fn get_gog_games_library(root: &RootsConfig) -> Option<Vec<GogLibraryGame>> {
-    log::trace!(
-        "get_gog_library searching for GOG information in {}",
-        root.path.interpret()
-    );
+    log::trace!("get_gog_library searching for GOG information in {:?}", &root.path);
 
     // use library.json to build map .app_name -> .title
     let libraries = [
@@ -144,17 +141,17 @@ pub fn get_gog_games_library(root: &RootsConfig) -> Option<Vec<GogLibraryGame>> 
     match serde_json::from_str::<GogLibrary>(&library_path.read().unwrap_or_default()) {
         Ok(gog_library) => {
             log::trace!(
-                "get_gog_library found {} games in {}",
+                "get_gog_library found {} games in {:?}",
                 gog_library.games.len(),
-                library_path.interpret()
+                &library_path
             );
 
             Some(gog_library.games)
         }
         Err(e) => {
             log::warn!(
-                "get_gog_library returns None since it could not read {}: {}",
-                library_path.interpret(),
+                "get_gog_library returns None since it could not read {:?}: {}",
+                &library_path,
                 e
             );
             None
@@ -165,10 +162,7 @@ pub fn get_gog_games_library(root: &RootsConfig) -> Option<Vec<GogLibraryGame>> 
 fn detect_gog_games(root: &RootsConfig, title_finder: &TitleFinder) -> HashMap<String, LauncherGame> {
     let mut games = HashMap::new();
 
-    log::trace!(
-        "detect_gog_games searching for GOG information in {}",
-        root.path.interpret()
-    );
+    log::trace!("detect_gog_games searching for GOG information in {:?}", &root.path);
 
     let game_titles: HashMap<String, String> = match get_gog_games_library(root) {
         Some(gog_games_library) => gog_games_library

--- a/src/scan/launchers/legendary.rs
+++ b/src/scan/launchers/legendary.rs
@@ -56,8 +56,8 @@ pub fn get_games(source: &StrictPath) -> Vec<Game> {
         Ok(content) => content,
         Err(e) => {
             log::debug!(
-                "In Legendary source '{}', unable to read installed.json | {:?}",
-                library.render(),
+                "In Legendary source '{:?}', unable to read installed.json | {:?}",
+                &library,
                 e,
             );
             return out;

--- a/src/scan/launchers/lutris.rs
+++ b/src/scan/launchers/lutris.rs
@@ -26,7 +26,7 @@ struct GameSection {
 pub fn scan(root: &RootsConfig, title_finder: &TitleFinder) -> HashMap<String, LauncherGame> {
     let mut games = HashMap::new();
 
-    log::trace!("Scanning Lutris root for games: {}", root.path.interpret());
+    log::trace!("Scanning Lutris root for games: {:?}", &root.path);
 
     for spec_path in root.path.joined("games/*.y*ml").glob() {
         log::debug!("Inspecting Lutris game file: {}", spec_path.render());
@@ -46,7 +46,7 @@ pub fn scan(root: &RootsConfig, title_finder: &TitleFinder) -> HashMap<String, L
         }
     }
 
-    log::trace!("Finished scanning Lutris root for games: {}", root.path.interpret());
+    log::trace!("Finished scanning Lutris root for games: {:?}", &root.path);
 
     games
 }

--- a/src/scan/launchers/lutris.rs
+++ b/src/scan/launchers/lutris.rs
@@ -93,7 +93,7 @@ fn scan_spec(spec: LutrisGame, spec_path: &StrictPath, title_finder: &TitleFinde
         let exe = if exe.is_absolute() {
             exe
         } else if let Some(prefix) = &prefix {
-            prefix.joined_raw(&exe.raw())
+            prefix.joined(&exe.raw())
         } else {
             log::info!(
                 "Skipping Lutris game file with relative exe and no prefix: {}",

--- a/src/scan/preview.rs
+++ b/src/scan/preview.rs
@@ -29,7 +29,7 @@ impl ScanInfo {
         } else {
             0
         };
-        successful_bytes - failed_bytes
+        successful_bytes.checked_sub(failed_bytes).unwrap_or_default()
     }
 
     pub fn total_possible_bytes(&self) -> u64 {

--- a/src/scan/registry.rs
+++ b/src/scan/registry.rs
@@ -208,7 +208,7 @@ fn read_registry_key(key: &winreg::RegKey) -> Entries {
 impl Hives {
     pub fn load(file: &StrictPath) -> Option<Self> {
         if file.is_file() {
-            let content = std::fs::read_to_string(file.interpret()).ok()?;
+            let content = file.read()?;
             Self::deserialize(&content)
         } else {
             None
@@ -226,7 +226,7 @@ impl Hives {
         }
 
         if file.create_parent_dir().is_ok() {
-            std::fs::write(file.interpret(), self.serialize().as_bytes()).unwrap();
+            let _ = file.write_with_content(&self.serialize());
         }
     }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -14,6 +14,26 @@ pub fn repo_raw() -> String {
     env!("CARGO_MANIFEST_DIR").to_string()
 }
 
+pub fn repo_file(path: &str) -> String {
+    repo_file_raw(path).replace('\\', "/")
+}
+
+pub fn repo_file_raw(path: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{}\\{}", repo_raw(), path.replace('/', "\\"))
+    } else {
+        format!("{}/{}", repo_raw(), path)
+    }
+}
+
+pub fn repo_path(path: &str) -> StrictPath {
+    StrictPath::new(repo_file(path))
+}
+
+pub fn repo_path_raw(path: &str) -> StrictPath {
+    StrictPath::new(repo_file_raw(path))
+}
+
 pub fn absolute_path(file: &str) -> StrictPath {
     if cfg!(target_os = "windows") {
         StrictPath::new(format!("X:{file}"))


### PR DESCRIPTION
Making a PR to give this better visibility, since it's a large chunk of work.

The `StrictPath` interface has been refactored to build from two internal representations, `display()` for pretty printing and `access()` for file IO, which both are based on a single `analyze()` method to split the drive and path segments. Also, `interpret()` is now fallible, so we can handle cases where file IO isn't possible on the host OS for a given path.

This fixes the problems in #185 and makes non-native path handling consistent on each host OS (although I'm sure some edge cases have escaped my testing so far).