### PR TITLE
Fix Wayland window associations

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -44,5 +44,10 @@ pub fn run(flags: Flags) {
         Err(_) => None,
     };
 
+    #[cfg(target_os = "linux")]
+    {
+        settings.window.platform_specific.application_id = "ludusavi".to_string();
+    }
+
     let _ = app::App::run(settings);
 }


### PR DESCRIPTION
Wayland compositors use the `appId`/`desktopFileName` window property in order to associate open windows with the correct `.desktop` file. Ludusavi wasn't setting this field, and iced doesn't appear to have any default behavior around it (Qt for example sets it by default to the binary name) which was causing it to be empty. This would mean that Wayland compositors would never associate ludusavi windows with the ludusavi.desktop launcher, which for example would cause KDE Plasma to show the generic Wayland icon in the top left of the and in the overview. If Ludusavi was pinned to a task manager clicking on it would also result in windows being opened as a new entry and not grouped under the Ludusavi icon. Fix both of those issues and various other erroneous behavior by setting the `appId` to the correct string (it should be the name of the `.desktop` file without the `.desktop` extension).

Before:
![image](https://github.com/mtkennerly/ludusavi/assets/4309817/54199b67-42fe-4813-8abd-2f5ac5aa3b92)

After:
![image](https://github.com/mtkennerly/ludusavi/assets/4309817/7e6ce0a7-bbf8-4253-b104-fcc0c083b62b)
