### PR TITLE
feat: add linux metadata keywords

### DIFF
--- a/assets/ludusavi.desktop
+++ b/assets/ludusavi.desktop
@@ -7,3 +7,4 @@ Exec=ludusavi
 Icon=ludusavi
 Terminal=false
 Categories=Game;
+Keywords=game;games;backup;save;saves;


### PR DESCRIPTION
Currently lacking keywords, therefore the app doesn't surface well when searching installed applications.

Example: search for `backup` - no result, because the only similar thing for it to go on is the comment "backing up". Similarly search for "saves" surfaces nothing, though "save" works.

This commit adds several keywords to improve this.