### PR TITLE
docs: explain cloud exclusions in backup previews

### DIFF
--- a/docs/help/backup-exclusions.md
+++ b/docs/help/backup-exclusions.md
@@ -6,3 +6,40 @@ Configure exclusions on the "other" screen.
 
 For excluded file paths, you can use glob syntax.
 For example, to exclude all files named `remotecache.vdf`, you would specify `**/remotecache.vdf`.
+
+## Cloud-supported games
+Ludusavi can skip games that have cloud save support on selected stores.
+You can configure this on the "other" screen.
+
+For example, if you enable cloud exclusions for Steam, then Ludusavi will skip
+games whose manifest says they support Steam Cloud. This can apply even if you
+installed the game through another launcher, because the cloud metadata belongs
+to the game itself, not just to your installed copy.
+
+This can be confusing when a game is installed and its saves are valid, but it
+does not appear in a full backup preview. For example:
+
+* You install a Windows game through Heroic.
+* Ludusavi detects the game and can find its save files.
+* The game also has Steam Cloud metadata in Ludusavi's manifest.
+* Steam cloud exclusions are enabled.
+* The game has no previous Ludusavi backup yet.
+
+In that case, a full backup preview may not list the game, because the cloud
+exclusion applies to first-time backups. You can still preview or back up the
+game explicitly.
+
+From the CLI, preview a specific game like this:
+
+```sh
+ludusavi backup --preview "Deus Ex: Mankind Divided"
+```
+
+Or back it up explicitly like this:
+
+```sh
+ludusavi backup "Deus Ex: Mankind Divided"
+```
+
+To include the game in full backup previews, disable the cloud exclusion for
+that store, or disable cloud exclusions entirely.

--- a/docs/help/missing-saves.md
+++ b/docs/help/missing-saves.md
@@ -30,6 +30,11 @@ then try double checking your [configured roots](/docs/help/roots.md).
 Ludusavi may only be able to scan some paths if an applicable root is configured.
 For example, having a Steam root will enable Ludusavi to check its `compatdata` folder.
 
+If Ludusavi can find a game when you preview it directly, but the game does not
+appear in a full backup preview, check your
+[backup exclusions](/docs/help/backup-exclusions.md). Cloud-supported game
+exclusions can hide first-time backups from full previews.
+
 ## Flatpak
 If you're using Flatpak on Linux, then by default,
 Ludusavi only has permission to view certain folders.


### PR DESCRIPTION
## Summary
- Document that cloud-supported game exclusions can hide first-time backups from full backup previews
- Add a concrete Heroic-installed Windows game scenario where direct preview works but full preview omits the game
- Link the missing-saves guide to backup exclusions for this case

## Verification
- git diff --check
- checked changed Markdown files for trailing whitespace, tabs, and final newlines

Note: pre-commit is not installed in this environment, so I verified the relevant Markdown hygiene checks directly.