### PR TITLE
Make is_absolute trim like the rest of StrictPath

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -866,7 +866,7 @@ impl StrictPath {
             Utf8WindowsComponent as WComponent,
         };
 
-        if let Some(component) = TypedPath::derive(&self.raw).components().next() {
+        if let Some(component) = TypedPath::derive(self.raw.trim()).components().next() {
             match component {
                 Component::Windows(WComponent::Prefix(_) | WComponent::RootDir)
                 | Component::Unix(UComponent::RootDir) => {
@@ -1755,6 +1755,26 @@ mod tests {
             assert_eq!("C:/tmp/foo".to_string(), path.display());
             assert_eq!(Ok(r"C:\tmp\foo".to_string()), path.access_windows());
             assert_eq!(Err(StrictPathError::Unsupported), path.access_nonwindows());
+        }
+
+        #[test]
+        fn is_absolute_ignores_surrounding_whitespace() {
+            // Every other method derives its typed path from the trimmed raw
+            // string, so is_absolute must trim too. A leading space should not
+            // make an otherwise absolute path report as relative.
+            assert!(StrictPath::new("/foo/bar").is_absolute());
+            assert!(StrictPath::new(" /foo/bar").is_absolute());
+            assert!(StrictPath::new("C:/foo").is_absolute());
+            assert!(StrictPath::new(" C:/foo").is_absolute());
+            assert!(!StrictPath::new("foo/bar").is_absolute());
+            assert!(!StrictPath::new(" foo/bar").is_absolute());
+
+            // The leading-space path is treated as absolute everywhere else, so
+            // is_absolute has to agree.
+            assert_eq!(
+                Analysis::new(Some(Drive::Root), vec!["foo".to_string(), "bar".to_string()]),
+                StrictPath::new(" /foo/bar").analyze()
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary

`StrictPath::is_absolute` derives its typed path from the untrimmed `self.raw`, while every other path-processing method trims first. `analyze_with_mode` uses `TypedPath::derive(self.raw.trim())`, and the glob helpers use `self.raw.trim()` too. `is_absolute` alone was missed.

The effect is that a `StrictPath` with leading whitespace is reported as relative by `is_absolute`, even though the rest of the type treats it as absolute. For `" /foo/bar"`, `TypedPath::derive(&self.raw)` sees the first component as a normal segment (`" "`) rather than a root, so `is_absolute` returns `false`, while `analyze()` yields `Drive::Root` with parts `[foo, bar]` and `access_nonwindows()` returns `Ok("/foo/bar")`. The two views of the same path disagree.

## Fix

One line, matching the trimming already done everywhere else:

```rust
-if let Some(component) = TypedPath::derive(&self.raw).components().next() {
+if let Some(component) = TypedPath::derive(self.raw.trim()).components().next() {
```

Behavior is unchanged for any path without surrounding whitespace.

## Testing

Added `is_absolute_ignores_surrounding_whitespace` in the existing `strict_path` tests, covering absolute and relative paths with and without a leading space, plus an assertion that the whitespace path is absolute everywhere else too. Verified it fails on `main` (`assertion failed: StrictPath::new(" /foo/bar").is_absolute()`) and passes with the fix. `cargo test --lib strict_path` is green (40 passed) and `cargo fmt --check` is clean.

## Notes

Severity is low: `is_absolute` is only called on paths parsed from external launcher configs (Steam, Lutris), where a leading space is unlikely, so I doubt anyone has hit it in practice. It is purely an internal-consistency fix, so I did not add a CHANGELOG entry since there is no user-visible behavior change. Happy to add one if you would prefer.
