### PR TITLE
Disambiguate colliding drive folder names to prevent silent data loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
     This is supported for Wine specifically, not any other native Linux paths.
     Currently, this only translates file paths, not the registry.
     ([Contributed by thedavidweng](https://github.com/mtkennerly/ludusavi/pull/614))
+* Fixed:
+  * Two distinct drives whose escaped folder names collided (such as the UNC
+    shares `\\a_b\c` and `\\a\b_c`) would share one backup folder, so saves from
+    one could silently overwrite the other. Colliding folder names are now
+    disambiguated with a numeric suffix.
+    ([Contributed by dkxmercury](https://github.com/mtkennerly/ludusavi/pull/631))
 
 ## v0.31.0 (2026-04-04)
 

--- a/src/scan/layout.rs
+++ b/src/scan/layout.rs
@@ -401,7 +401,18 @@ impl IndividualMapping {
         match reversed.get::<str>(drive) {
             Some(mapped) => mapped.to_string(),
             None => {
-                let key = Self::new_drive_folder_name(drive);
+                // The escaped folder name is not injective (e.g. distinct UNC
+                // shares like \\a_b\c and \\a\b_c both escape to the same
+                // string), so disambiguate on collision. Otherwise two drives
+                // share one backup folder and saves from one silently overwrite
+                // the other.
+                let base = Self::new_drive_folder_name(drive);
+                let mut key = base.clone();
+                let mut suffix = 2;
+                while self.drives.get(&key).is_some_and(|existing| existing != drive) {
+                    key = format!("{base}-{suffix}");
+                    suffix += 1;
+                }
                 self.drives.insert(key.to_string(), drive.to_string());
                 key
             }
@@ -2355,6 +2366,27 @@ mod tests {
             assert_eq!("drive-D", mapping.drive_folder_name("D:"));
             assert_eq!("drive-____C", mapping.drive_folder_name(r#"\\?\C:"#));
             assert_eq!("drive-__remote", mapping.drive_folder_name(r#"\\remote"#));
+        }
+
+        #[test]
+        fn distinct_unc_drives_do_not_collide_to_same_folder() {
+            let mut mapping = IndividualMapping::new("foo".to_owned());
+            // Two valid but distinct Windows UNC shares that escape to the same
+            // string: server "a_b" share "c" vs server "a" share "b_c".
+            let folder1 = mapping.drive_folder_name(r#"\\a_b\c"#);
+            let folder2 = mapping.drive_folder_name(r#"\\a\b_c"#);
+
+            // They must map to different backup folders, otherwise saves from
+            // one share silently overwrite saves from the other.
+            assert_ne!(folder1, folder2, "distinct UNC drives collided to folder {folder1}");
+
+            // And both shares must be retained in the drives map, not just the last.
+            assert_eq!(
+                2,
+                mapping.drives.len(),
+                "drives map lost an entry: {:?}",
+                mapping.drives
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

`IndividualMapping::drive_folder_name` can map two distinct drives to the same backup folder, so saves from one silently overwrite the other and a restore cannot tell them apart.

## Root cause

A drive is turned into a backup folder name by `new_drive_folder_name` -> `escape_folder_name`, which replaces every `INVALID_FILE_CHARS` entry (including the path separator `\`) with `_`. That escaping is not injective, so different drives can escape to the same string. Two fully valid but distinct Windows UNC shares are enough:

```
\\a_b\c   (server "a_b", share "c")   -> drive-__a_b_c
\\a\b_c   (server "a",   share "b_c") -> drive-__a_b_c
```

When both are backed up, `drive_folder_name` computes the same key for each and does `self.drives.insert(key, drive)` with no collision check, so:

- both drives resolve to one `drive-__a_b_c` folder, and files at the same relative path overwrite each other (silent data loss), and
- the `drives` map in `mapping.yaml` keeps only the last drive for that key, so a restore can no longer map the folder back to the right share.

## Fix

Disambiguate on collision with a numeric suffix and persist the chosen key:

```
drive-__a_b_c, drive-__a_b_c-2, drive-__a_b_c-3, ...
```

The reverse lookup used by the immutable variant (restore) reads the persisted key, so it stays correct. Non-colliding drives are unchanged, so existing backups keep their folder names.

## Testing

Added `distinct_unc_drives_do_not_collide_to_same_folder`. It fails on `main` (both shares return `drive-__a_b_c`, and the `drives` map holds a single entry) and passes with the fix. `cargo fmt --check` is clean.

One honest note on my local run: 5 `..._with_registry` tests in `scan::layout` fail in my environment both before and after this change (they read the live Windows registry and my box does not have the fixtures set up). They are unrelated to this change, and the rest of `scan::layout` plus the new test pass. CI on a proper Windows runner will exercise them.

## Notes

The trigger is narrow (it needs two colliding drive names in one backup, most likely UNC shares whose names differ only by where an underscore versus a separator falls), but the consequence is silent data loss, which seemed worth closing off. I added a CHANGELOG entry under Fixed.
