### PR TITLE
Return None from parent() for a bare Windows drive root

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -838,7 +838,10 @@ impl StrictPath {
 
     pub fn parent(&self) -> Option<Self> {
         let popped = self.popped();
-        (self != &popped).then_some(popped)
+        // Compare by analysis rather than raw string. A bare drive root like
+        // "C:" pops to "C:/", a different string that denotes the same location,
+        // and should have no parent, matching the Unix root "/".
+        (self.analyze() != popped.analyze()).then_some(popped)
     }
 
     pub fn parent_if_file(&self) -> Result<Self, StrictPathError> {
@@ -1849,6 +1852,21 @@ mod tests {
             check!(r"C:", r"C:");
             check!(r"C:\", r"C:");
             check!(r"C:/", r"C:");
+        }
+
+        #[test]
+        fn parent_of_a_root_is_none() {
+            // A Unix root has no parent, and a bare Windows drive root should
+            // behave the same instead of reporting itself (as "C:/") as its parent.
+            assert_eq!(None, StrictPath::new("/".to_string()).parent());
+            assert_eq!(None, StrictPath::new("C:".to_string()).parent());
+            assert_eq!(None, StrictPath::new("C:/".to_string()).parent());
+
+            // A non-root path still has the expected parent.
+            assert_eq!(
+                Some(StrictPath::new("C:/foo".to_string())),
+                StrictPath::new("C:/foo/bar".to_string()).parent()
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary

`StrictPath::new("C:").parent()` returns `Some("C:/")` instead of `None`, so a bare Windows drive root reports itself as its own parent. The Unix root `/` correctly returns `None`.

## Root cause

`parent()` compares the path against `popped()` by raw string:

```rust
let popped = self.popped();
(self != &popped).then_some(popped)
```

For `/`, `popped()` produces `/`, which equals the raw string, so `parent()` returns `None`. For a bare drive root `C:`, `popped()` formats it as `C:/` (a different string that denotes the same location), so `self != popped` holds and `parent()` returns `Some("C:/")`. Walking parents from a Windows drive root therefore takes one extra step (`C:` -> `C:/` -> `None`) that the Unix root does not.

## Fix

Compare by analysis rather than raw string, so two spellings of the same location are treated as equal:

```rust
(self.analyze() != popped.analyze()).then_some(popped)
```

`analyze("C:")` and `analyze("C:/")` are identical, so a drive root now yields `None`. This only affects the root case; `parent()` of any non-root path is unchanged, since `popped()` itself is untouched.

## Testing

Added `parent_of_a_root_is_none`, asserting `None` for `/`, `C:`, and `C:/`, and the expected parent for a non-root path. It fails on `main` (the `C:` case returns `Some("C:/")`) and passes with the fix. The full `path::` test suite passes (40 tests) and `cargo fmt --check` is clean.

## Notes

Low severity, no crash and no data loss, just a wrong/inconsistent value at a drive root. I left the CHANGELOG alone since there is no real user-visible change, but happy to add an entry if you would prefer.
