### PR TITLE
Expose manifest file tags in the API output

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -6,7 +6,7 @@ use crate::{
     cloud::CloudChange,
     lang::TRANSLATOR,
     prelude::StrictPath,
-    resource::manifest::Os,
+    resource::manifest::{Os, Tag},
     scan::{
         BackupError, BackupInfo, DuplicateDetector, OperationStatus, OperationStepDecision, ScanChange, ScanInfo,
         TitleMatch, compare_ranked_titles_ref, layout::Backup, registry,
@@ -98,6 +98,10 @@ pub struct ApiFile {
     /// Any other games that also have the same file path.
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
     pub duplicated_by: BTreeSet<String>,
+    /// Manifest tags describing the kind of data, such as `save` or `config`.
+    /// Only set when backing up, since the tags come from the manifest.
+    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    pub tags: BTreeSet<Tag>,
 }
 
 #[derive(Debug, Default, serde::Serialize, schemars::JsonSchema)]
@@ -429,6 +433,7 @@ impl Reporter {
                             .and_then(|x| x.failed_files.get(scan_key).map(SaveError::from)),
                         ignored: entry.ignored,
                         change: entry.change(),
+                        tags: entry.tags.clone(),
                         ..Default::default()
                     };
                     if !duplicate_detector.is_file_duplicated(scan_key, entry).resolved() {
@@ -736,6 +741,7 @@ Overall:
                         change: Default::default(),
                         container: None,
                         redirected: None,
+                        tags: Default::default(),
                     },
                     "/file2".into(): ScannedFile {
                         size: 51_200,
@@ -745,6 +751,7 @@ Overall:
                         change: Default::default(),
                         container: None,
                         redirected: None,
+                        tags: Default::default(),
                     },
                 },
                 found_registry_keys: hash_map! {
@@ -805,6 +812,7 @@ Overall:
                         change: ScanChange::Same,
                         container: None,
                         redirected: None,
+                        tags: Default::default(),
                     },
                 },
                 found_registry_keys: hash_map! {},
@@ -828,6 +836,7 @@ Overall:
                         change: Default::default(),
                         container: None,
                         redirected: None,
+                        tags: Default::default(),
                     },
                 },
                 found_registry_keys: hash_map! {},
@@ -873,6 +882,7 @@ Overall:
                         change: Default::default(),
                         container: None,
                         redirected: None,
+                        tags: Default::default(),
                     },
                     "/backup/file2".into(): ScannedFile {
                         size: 51_200,
@@ -882,6 +892,7 @@ Overall:
                         change: Default::default(),
                         container: None,
                         redirected: None,
+                        tags: Default::default(),
                     },
                 },
                 found_registry_keys: hash_map! {},
@@ -1214,6 +1225,7 @@ Overall:
                         change: Default::default(),
                         container: None,
                         redirected: None,
+                        tags: Default::default(),
                     },
                     "/backup/file2".into(): ScannedFile {
                         size: 50,
@@ -1223,6 +1235,7 @@ Overall:
                         change: Default::default(),
                         container: None,
                         redirected: None,
+                        tags: Default::default(),
                     },
                 },
                 found_registry_keys: hash_map! {},

--- a/src/resource/manifest.rs
+++ b/src/resource/manifest.rs
@@ -173,7 +173,19 @@ impl ToString for Store {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+)]
 #[serde(rename_all = "camelCase")]
 pub enum Tag {
     Save,

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -12,7 +12,7 @@ pub mod steam;
 pub mod title;
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     sync::LazyLock,
 };
 
@@ -37,7 +37,7 @@ use crate::{
         config::{
             BackupFilter, Config, RedirectConfig, RedirectKind, Root, SortKey, ToggledPaths, ToggledRegistry, root,
         },
-        manifest::{Game, GameFileEntry, IdSet, Os, Store},
+        manifest::{Game, GameFileEntry, IdSet, Os, Store, Tag},
     },
     scan::layout::{BackupSemantics, DirectorySemantics, LatestBackup, SemanticDirKind},
 };
@@ -542,7 +542,7 @@ pub fn scan_game_for_backup(
 ) -> ScanInfo {
     log::trace!("[{name}] beginning scan for backup");
 
-    let mut found_files = HashMap::new();
+    let mut found_files: HashMap<StrictPath, ScannedFile> = HashMap::new();
     #[cfg_attr(not(target_os = "windows"), allow(unused))]
     let mut found_registry_keys = HashMap::new();
     #[allow(unused)]
@@ -550,6 +550,10 @@ pub fn scan_game_for_backup(
     let has_backups = previous.is_some();
 
     let mut paths_to_check = HashSet::<(StrictPath, Option<bool>)>::new();
+    // Manifest tags for each candidate path, so found files can report whether
+    // they are saves, configs, and so on. Paths that overlap accumulate all of
+    // their tags.
+    let mut path_tags = HashMap::<StrictPath, BTreeSet<Tag>>::new();
 
     // Add a dummy root for checking paths without `<root>`.
     let mut roots_to_check: Vec<Root> = vec![Root::new(SKIP, Store::Other)];
@@ -650,6 +654,12 @@ pub fn scan_game_for_backup(
 
             for (candidate, case_sensitive) in candidates {
                 log::trace!("[{name}] parsed candidate: {candidate:?}");
+                if !path_data.tags.is_empty() {
+                    path_tags
+                        .entry(candidate.clone())
+                        .or_default()
+                        .extend(path_data.tags.iter().cloned());
+                }
                 paths_to_check.insert((candidate, Some(case_sensitive)));
             }
         }
@@ -716,6 +726,7 @@ pub fn scan_game_for_backup(
             log::debug!("[{name}] excluded: {path:?}");
             continue;
         }
+        let tags = path_tags.get(&path).cloned().unwrap_or_default();
         let paths = match case_sensitive {
             None => path.glob(),
             Some(cs) => path.glob_case_sensitive(cs),
@@ -743,9 +754,10 @@ pub fn scan_game_for_backup(
                 );
                 let change =
                     ScanChange::evaluate_backup(&hash, previous_files.get(redirected.as_ref().unwrap_or(&scan_key)));
-                found_files.insert(
-                    scan_key,
-                    ScannedFile {
+                found_files
+                    .entry(scan_key)
+                    .and_modify(|existing| existing.tags.extend(tags.iter().cloned()))
+                    .or_insert_with(|| ScannedFile {
                         change,
                         size,
                         hash,
@@ -753,8 +765,8 @@ pub fn scan_game_for_backup(
                         original_path: None,
                         ignored,
                         container: None,
-                    },
-                );
+                        tags: tags.clone(),
+                    });
             } else if p.is_dir() {
                 log::trace!("[{name}] looking for files in: {p:?}");
                 for child in walkdir::WalkDir::new(p.as_std_path_buf().unwrap())
@@ -794,9 +806,10 @@ pub fn scan_game_for_backup(
                             &hash,
                             previous_files.get(redirected.as_ref().unwrap_or(&scan_key)),
                         );
-                        found_files.insert(
-                            scan_key,
-                            ScannedFile {
+                        found_files
+                            .entry(scan_key)
+                            .and_modify(|existing| existing.tags.extend(tags.iter().cloned()))
+                            .or_insert_with(|| ScannedFile {
                                 change,
                                 size,
                                 hash,
@@ -804,8 +817,8 @@ pub fn scan_game_for_backup(
                                 original_path: None,
                                 ignored,
                                 container: None,
-                            },
-                        );
+                                tags: tags.clone(),
+                            });
                     }
                 }
             }
@@ -840,6 +853,7 @@ pub fn scan_game_for_backup(
                     original_path: None,
                     ignored: ignored_paths.is_ignored(name, previous_file),
                     container: None,
+                    tags: Default::default(),
                 },
             );
         }
@@ -1349,6 +1363,51 @@ mod tests {
     }
 
     #[test]
+    fn can_scan_game_for_backup_with_tags() {
+        let manifest = Manifest::load_from_string(
+            r#"
+            game1:
+              files:
+                <base>/file1.txt:
+                  tags:
+                    - config
+                <base>/subdir:
+                  tags:
+                    - save
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            ScanInfo {
+                game_name: s("game1"),
+                found_files: hash_map! {
+                    format!("{}/tests/root1/game1/subdir/file2.txt", repo()).into(): ScannedFile::with_tags(2, "9d891e731f75deae56884d79e9816736b7488080", BTreeSet::from([Tag::Save])).change_new(),
+                    format!("{}/tests/root2/game1/file1.txt", repo()).into(): ScannedFile::with_tags(1, "3a52ce780950d4d969792a2559cd519d7ee8c727", BTreeSet::from([Tag::Config])).change_new(),
+                },
+                found_registry_keys: hash_map! {},
+                ..Default::default()
+            },
+            scan_game_for_backup(
+                &manifest.0["game1"],
+                "game1",
+                &config().roots,
+                &StrictPath::new(repo()),
+                &Launchers::scan_dirs(&config().roots, &manifest, &["game1".to_string()]),
+                &BackupFilter::default(),
+                None,
+                &ToggledPaths::default(),
+                &ToggledRegistry::default(),
+                None,
+                &[],
+                false,
+                &Default::default(),
+                ONLY_CONSTRUCTIVE,
+            ),
+        );
+    }
+
+    #[test]
     fn can_scan_game_for_backup_deduplicating_symlinks() {
         let roots = &[Root::new(format!("{}/tests/root3", repo()), Store::Other)];
         assert_eq!(
@@ -1394,6 +1453,7 @@ mod tests {
                         change: ScanChange::New,
                         container: None,
                         redirected: Some(StrictPath::new(format!("{}/tests/root3/game5/data-symlink/file1.txt", repo()))),
+                        tags: Default::default(),
                     },
                 },
                 found_registry_keys: hash_map! {},
@@ -1762,6 +1822,7 @@ mod tests {
                         change: ScanChange::Unknown,
                         container: None,
                         redirected: Some(current_path.clone()),
+                        tags: Default::default(),
                     },
                 },
                 ..Default::default()
@@ -1809,6 +1870,7 @@ mod tests {
                         change: ScanChange::Unknown,
                         container: None,
                         redirected: None,
+                        tags: Default::default(),
                     },
                 },
                 ..Default::default()

--- a/src/scan/duplicate.rs
+++ b/src/scan/duplicate.rs
@@ -464,6 +464,7 @@ mod tests {
             change: Default::default(),
             container: None,
             redirected: None,
+            tags: Default::default(),
         };
         let scan_key_1b = StrictPath::from("file1b.txt");
         let file1b = ScannedFile {
@@ -474,6 +475,7 @@ mod tests {
             change: Default::default(),
             container: None,
             redirected: None,
+            tags: Default::default(),
         };
 
         detector.add_game(
@@ -516,6 +518,7 @@ mod tests {
                     change: Default::default(),
                     container: None,
                     redirected: None,
+                    tags: Default::default(),
                 }
             )
         );
@@ -543,6 +546,7 @@ mod tests {
                     change: Default::default(),
                     container: None,
                     redirected: None,
+                    tags: Default::default(),
                 }
             )
         );

--- a/src/scan/layout.rs
+++ b/src/scan/layout.rs
@@ -792,6 +792,7 @@ impl GameLayout {
                             ignored: toggled_paths.is_ignored(&self.mapping.name, ignorable_path),
                             redirected,
                             original_path: Some(original_path),
+                            tags: Default::default(),
                             container: None,
                         },
                     );
@@ -813,6 +814,7 @@ impl GameLayout {
                             ignored: toggled_paths.is_ignored(&self.mapping.name, ignorable_path),
                             redirected,
                             original_path: Some(original_path),
+                            tags: Default::default(),
                             container: Some(self.path.joined(&backup.name)),
                         },
                     );
@@ -867,6 +869,7 @@ impl GameLayout {
                             ignored: toggled_paths.is_ignored(&self.mapping.name, ignorable_path),
                             redirected,
                             original_path: Some(original_path),
+                            tags: Default::default(),
                             container: None,
                         },
                     );
@@ -888,6 +891,7 @@ impl GameLayout {
                             ignored: toggled_paths.is_ignored(&self.mapping.name, ignorable_path),
                             redirected,
                             original_path: Some(original_path),
+                            tags: Default::default(),
                             container: Some(self.path.joined(&backup.name)),
                         },
                     );
@@ -938,6 +942,7 @@ impl GameLayout {
                         ignored: false,
                         container: None,
                         redirected: None,
+                        tags: Default::default(),
                     },
                 );
             }
@@ -3249,6 +3254,7 @@ mod tests {
                         container: None,
                         redirected: None,
 
+                        tags: Default::default(),
                     },
                     make_restorable_path("backup-1", "file2.txt"): ScannedFile {
                         size: 2,
@@ -3259,6 +3265,7 @@ mod tests {
                         container: None,
                         redirected: None,
 
+                        tags: Default::default(),
                     },
                 },
                 layout.restorable_files(
@@ -3301,6 +3308,7 @@ mod tests {
                         container: Some(make_path("backup-1.zip")),
                         redirected: None,
 
+                        tags: Default::default(),
                     },
                     make_restorable_path_zip("file2.txt"): ScannedFile {
                         size: 2,
@@ -3311,6 +3319,7 @@ mod tests {
                         container: Some(make_path("backup-1.zip")),
                         redirected: None,
 
+                        tags: Default::default(),
                     },
                 },
                 layout.restorable_files(
@@ -3364,6 +3373,7 @@ mod tests {
                         container: None,
                         redirected: None,
 
+                        tags: Default::default(),
                     },
                     make_restorable_path("backup-2", "changed.txt"): ScannedFile {
                         size: 2,
@@ -3374,6 +3384,7 @@ mod tests {
                         container: None,
                         redirected: None,
 
+                        tags: Default::default(),
                     },
                     make_restorable_path("backup-2", "added.txt"): ScannedFile {
                         size: 5,
@@ -3384,6 +3395,7 @@ mod tests {
                         container: None,
                         redirected: None,
 
+                        tags: Default::default(),
                     },
                 },
                 layout.restorable_files(
@@ -3507,6 +3519,7 @@ mod tests {
                         container: Some(make_path("backup-1.zip")),
                         redirected: None,
 
+                        tags: Default::default(),
                     },
                     make_restorable_path_zip("changed.txt"): ScannedFile {
                         size: 2,
@@ -3517,6 +3530,7 @@ mod tests {
                         container: Some(make_path("backup-2.zip")),
                         redirected: None,
 
+                        tags: Default::default(),
                     },
                     make_restorable_path_zip("added.txt"): ScannedFile {
                         size: 5,
@@ -3527,6 +3541,7 @@ mod tests {
                         container: Some(make_path("backup-2.zip")),
                         redirected: None,
 
+                        tags: Default::default(),
                     },
                 },
                 layout.restorable_files(
@@ -3614,6 +3629,7 @@ mod tests {
                             container: None,
                             redirected: None,
 
+                        tags: Default::default(),
                     },
                         restorable_file_simple(SOLO, "file2.txt"): ScannedFile {
                             size: 2,
@@ -3624,6 +3640,7 @@ mod tests {
                             container: None,
                             redirected: None,
 
+                        tags: Default::default(),
                     },
                     },
                     found_registry_keys: Default::default(),

--- a/src/scan/saves.rs
+++ b/src/scan/saves.rs
@@ -1,7 +1,8 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
     prelude::StrictPath,
+    resource::manifest::Tag,
     scan::{ScanChange, ScanKind},
 };
 
@@ -16,6 +17,8 @@ pub struct ScannedFile {
     /// An enclosing archive file, if any, depending on the `BackupFormat`.
     pub container: Option<StrictPath>,
     pub redirected: Option<StrictPath>,
+    /// Manifest tags describing the kind of data (e.g. save or config).
+    pub tags: BTreeSet<Tag>,
 }
 
 impl ScannedFile {
@@ -29,6 +32,7 @@ impl ScannedFile {
             change: Default::default(),
             container: None,
             redirected: None,
+            tags: Default::default(),
         }
     }
 
@@ -42,6 +46,21 @@ impl ScannedFile {
             change,
             container: None,
             redirected: None,
+            tags: Default::default(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_tags<H: ToString>(size: u64, hash: H, tags: BTreeSet<Tag>) -> Self {
+        Self {
+            size,
+            hash: hash.to_string(),
+            original_path: None,
+            ignored: false,
+            change: Default::default(),
+            container: None,
+            redirected: None,
+            tags,
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a `tags` field to each file in the `--api` JSON output, so consumers can tell which files are saves versus configs (and anything else the manifest tags). This is what #534 asked for.

The tags come straight from the manifest entries that matched a file, so a file gets `save`, `config`, etc. based on the paths it was found under. As mentioned in the issue, paths can overlap (for example a config directory that contains the save directory), so when more than one manifest entry resolves to the same file its tags are unioned rather than one winning. The field is omitted when empty, so existing output is unchanged and restore output (which has no manifest tags) is unaffected.

## Implementation notes

- `ScannedFile` now carries the tags collected while scanning for backup.
- During the backup scan, tags from each manifest file entry are tracked per candidate path and attached to the files found under it, accumulating across overlapping paths.
- `ApiFile` exposes them as `tags`, skipped when empty.

I left the generated `docs/schema` files alone since regenerating them here also pulls in an unrelated schemars format bump, so that seems better left for a release.

## Testing

- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- --deny warnings`

Added `can_scan_game_for_backup_with_tags` covering a config file and a save directory.

Closes #534
