### PR TITLE
Prevent --full-limit 0 from discarding all backups

### DIFF
--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -1211,7 +1211,7 @@ mod tests {
             &["ludusavi", "restore", "--path", "tests/fake"],
             clap::error::ErrorKind::ValueValidation,
         );
-    }606847
+    }
     
 
     #[test]

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -193,7 +193,7 @@ pub enum Subcommand {
         /// Maximum number of full backups to retain per game.
         /// Must be between 1 and 255 (inclusive).
         /// When not specified, this defers to the config file.
-        #[clap(long)]
+        #[clap(long, value_parser = clap::value_parser!(u8).range(1..))]
         full_limit: Option<u8>,
 
         /// Maximum number of differential backups to retain per full backup.
@@ -493,7 +493,7 @@ pub enum Subcommand {
         /// Maximum number of full backups to retain per game.
         /// Must be between 1 and 255 (inclusive).
         /// When not specified, this defers to the config file.
-        #[clap(long)]
+        #[clap(long, value_parser = clap::value_parser!(u8).range(1..))]
         full_limit: Option<u8>,
 
         /// Maximum number of differential backups to retain per full backup.
@@ -1211,8 +1211,25 @@ mod tests {
             &["ludusavi", "restore", "--path", "tests/fake"],
             clap::error::ErrorKind::ValueValidation,
         );
+    }606847
+    
+
+    #[test]
+    fn rejects_cli_backup_with_full_limit_of_zero() {
+        check_args_err(
+            &["ludusavi", "backup", "--full-limit", "0"],
+            clap::error::ErrorKind::ValueValidation,
+        );
     }
 
+    #[test]
+    fn rejects_cli_wrap_with_full_limit_of_zero() {
+        check_args_err(
+            &["ludusavi", "wrap", "--name", "game1", "--full-limit", "0"],
+            clap::error::ErrorKind::ValueValidation,
+        );
+    }
+    
     #[test]
     fn accepts_cli_restore_with_sort_variants() {
         let cases = [


### PR DESCRIPTION
The problem is "--full-limit" documents that it "must be between 1 and 255 (inclusive)", and the GUI enforces 1..=255 for the same setting, but the CLI accepts "--full-limit 0", which silently discards every backup for the affected games.

Reproduced on master, with a custom game pointing at /tmp/lv-repro/saves and an empty backup target:
```
$ ludusavi --config /tmp/lv-repro/config --no-manifest-update backup --path /tmp/lv-repro/backups --force --full-limit 1 "Test Game"
Test Game [19 B] [+]:
  - [+] /tmp/lv-repro/saves/save.txt

Overall:
  Games: 1 [+1]
  Size: 19 B
  Location: /tmp/lv-repro/backups

$ ludusavi --config /tmp/lv-repro/config --no-manifest-update backups --path /tmp/lv-repro/backups
Test Game:
  Folder: /tmp/lv-repro/backups/Test Game
  - "." (2026-09-01T02:30:32) [Linux]

$ echo "more progress" >> /tmp/lv-repro/saves/save.txt

$ ludusavi --config /tmp/lv-repro/config --no-manifest-update backup --path /tmp/lv-repro/backups --force --full-limit 0 "Test Game"
Test Game [33 B] [Δ]:
  - [Δ] /tmp/lv-repro/saves/save.txt

Overall:
  Games: 1 [Δ1]
  Size: 33 B
  Location: /tmp/lv-repro/backups

$ ludusavi --config /tmp/lv-repro/config --no-manifest-update backups --path /tmp/lv-repro/backups

$ find /tmp/lv-repro/backups -type f
/tmp/lv-repro/backups/Test Game/mapping.yaml
```
Exit code is 0, but the game ends up with no backups at all, including the ones it had before: "forget_excess_backups" computes "unlocked_fulls.saturating_sub(0)", so every unlocked full is excess and gets pruned from disk.

What changued?
Range-validate "--full-limit" for backup and wrap, matching the help text and the GUI. "--differential-limit" is untouched, since 0 is meaningful there. Two parse tests included.

And if you'd rather make "0" mean "keep everything" for [#597](https://github.com/mtkennerly/ludusavi/issues/597), that fixes this too and I'll redo the PR that way. The config file still accepts "retention.full: 0"; validating on load felt like your call.